### PR TITLE
fix(date): Use local timezone for dashboard URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
     }
 
     function abrirOrderManagementRato() {
-      const agora = new Date().toISOString();
+      const agora = getLocalISOString(new Date());
       const url = new URL("https://perform.lyzer.tech/pt/app/operations/order-management");
       url.searchParams.append("dateRange[from]", agora);
       ["191", "190"].forEach(st => url.searchParams.append("serviceTypes", st));
@@ -43,7 +43,7 @@
     }
 
     function abrirLiveOperationsRato() {
-      const agora = new Date().toISOString();
+      const agora = getLocalISOString(new Date());
       const url = new URL("https://perform.lyzer.tech/pt/app/operations/live-operations");
       url.searchParams.append("deliveryDeadline", agora);
       url.searchParams.append("retailer", "29");
@@ -57,6 +57,12 @@
 
     function abrirMensagemWhatsApp() {
       window.open("mensagem.html", "_blank");
+    }
+
+    function getLocalISOString(date) {
+      const offset = date.getTimezoneOffset();
+      const dateWithOffset = new Date(date.getTime() - (offset * 60 * 1000));
+      return dateWithOffset.toISOString().slice(0, -1);
     }
   </script>
 </body>


### PR DESCRIPTION
The `abrirOrderManagementRato` and `abrirLiveOperationsRato` functions were using `new Date().toISOString()` to generate timestamps for the dashboard URLs. This method returns the date and time in UTC.

This caused an issue for users in different timezones, as the dashboard could show data for the incorrect day.

This commit replaces `new Date().toISOString()` with a new helper function, `getLocalISOString`, which generates an ISO-like timestamp based on the user's local timezone. This ensures that the dashboard URLs always contain the correct local date for the user.