### PR TITLE
feat: add gmail and outlook options to contact form

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -54,8 +54,17 @@
         </select>
       </div>
 
-      <button type="submit" class="btn-primary">Enviar E-mail</button>
+      <button type="submit" class="btn-primary">Criar E-mail</button>
     </form>
+
+    <div id="email_options" style="display: none; margin-top: 20px; text-align: center;">
+      <h3 style="margin-bottom: 15px;">Escolha como deseja enviar:</h3>
+      <div style="display: flex; flex-direction: column; gap: 10px;">
+        <a id="btn-gmail" href="#" target="_blank" class="btn-primary" style="text-decoration: none; display: inline-block; background-color: #DB4437; color: white; padding: 12px; border-radius: 8px;">Abrir no Gmail</a>
+        <a id="btn-outlook" href="#" target="_blank" class="btn-primary" style="text-decoration: none; display: inline-block; background-color: #0078D4; color: white; padding: 12px; border-radius: 8px;">Abrir no Outlook Web</a>
+        <a id="btn-default" href="#" class="btn-primary" style="text-decoration: none; display: inline-block; background-color: #6c757d; color: white; padding: 12px; border-radius: 8px;">App Padrão de E-mail (Telefone / PC)</a>
+      </div>
+    </div>
   </div>
 
   <script>
@@ -98,7 +107,21 @@
         }
 
         const mailtoLink = `mailto:${to}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
-        window.location.href = mailtoLink;
+
+        // Gmail Web Compose Link
+        const gmailLink = `https://mail.google.com/mail/?view=cm&fs=1&to=${encodeURIComponent(to)}&su=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+
+        // Outlook Web Compose Link
+        const outlookLink = `https://outlook.office.com/mail/deeplink/compose?to=${encodeURIComponent(to)}&subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+
+        document.getElementById('btn-gmail').href = gmailLink;
+        document.getElementById('btn-outlook').href = outlookLink;
+        document.getElementById('btn-default').href = mailtoLink;
+
+        document.getElementById('email_options').style.display = 'block';
+
+        // Scroll to the options
+        document.getElementById('email_options').scrollIntoView({ behavior: 'smooth' });
       });
     });
 

--- a/test_contact.py
+++ b/test_contact.py
@@ -1,0 +1,48 @@
+import threading
+import http.server
+import socketserver
+import time
+from playwright.sync_api import sync_playwright
+
+PORT = 8000
+
+Handler = http.server.SimpleHTTPRequestHandler
+httpd = socketserver.TCPServer(("", PORT), Handler)
+
+def start_server():
+    httpd.serve_forever()
+
+thread = threading.Thread(target=start_server, daemon=True)
+thread.start()
+time.sleep(1) # wait for server to start
+
+try:
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page()
+        page.goto(f'http://localhost:{PORT}/contact.html')
+
+        page.fill('input#encomenda', '123 / 456789')
+        page.select_option('select#motivo', 'artigo esquecido em loja')
+
+        page.click('button[type="submit"]')
+
+        page.wait_for_selector('#email_options', state='visible')
+
+        gmail_href = page.get_attribute('#btn-gmail', 'href')
+        outlook_href = page.get_attribute('#btn-outlook', 'href')
+        default_href = page.get_attribute('#btn-default', 'href')
+
+        assert "mail.google.com" in gmail_href, f"Gmail URL missing: {gmail_href}"
+        assert "outlook.office.com" in outlook_href, f"Outlook URL missing: {outlook_href}"
+        assert "mailto:" in default_href, f"Default mailto missing: {default_href}"
+
+        print("Success! All buttons are visible and have correct hrefs:")
+        print(f"Gmail: {gmail_href[:50]}...")
+        print(f"Outlook: {outlook_href[:50]}...")
+        print(f"Default: {default_href[:50]}...")
+
+        browser.close()
+finally:
+    httpd.shutdown()
+    httpd.server_close()


### PR DESCRIPTION
Replaced immediate `mailto:` action in `contact.html` with an explicit options menu, providing dedicated links for Gmail, Outlook Web, and the default mail app. This resolves issues on browsers like Chrome where default mail handlers may not be configured.

---
*PR created automatically by Jules for task [3395743019634501356](https://jules.google.com/task/3395743019634501356) started by @divilella96*