### PR TITLE
⚡ Bolt: Debounce map search input to reduce DOM/map re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-20 - Debounce map search input
+**Learning:** In a static HTML page relying heavily on DOM manipulation and Leaflet map rendering (e.g., `mapa_emel.html`), invoking rendering functions on every `keyup` event causes significant UI lag when typing.
+**Action:** Always wrap search input handlers that trigger complex DOM updates or map re-renders with a debounce function (e.g., `setTimeout` / `clearTimeout` with ~300ms delay) to ensure performance remains smooth during user input.

--- a/mapa_emel.html
+++ b/mapa_emel.html
@@ -470,13 +470,18 @@
       renderCards(input);
     }
 
+    let filterMapTimeout;
+
     function filterMap() {
-      const input = document.getElementById('streetInput').value.trim();
-      // On keyup we might just want to update the list, but maybe not the map zoom yet to avoid jumping?
-      // Let's update both for responsiveness.
-      const matches = filterData(input);
-      renderMarkers(matches); // This will zoom to fit bounds of matches
-      renderCards(input);
+      clearTimeout(filterMapTimeout);
+      filterMapTimeout = setTimeout(() => {
+        const input = document.getElementById('streetInput').value.trim();
+        // On keyup we might just want to update the list, but maybe not the map zoom yet to avoid jumping?
+        // Let's update both for responsiveness.
+        const matches = filterData(input);
+        renderMarkers(matches); // This will zoom to fit bounds of matches
+        renderCards(input);
+      }, 300);
     }
 
     // Initialize


### PR DESCRIPTION
💡 What: Added a 300ms debounce to the `filterMap` function in `mapa_emel.html` that handles the `keyup` event for the search input.
🎯 Why: The original implementation triggered complex map re-renders (via Leaflet) and DOM updates (rebuilding the street cards) on every single keystroke. This causes noticeable lag, especially for fast typists.
📊 Impact: Eliminates redundant function calls and DOM/map re-renders while typing. Re-rendering only occurs once the user stops typing for 300ms, making the application measurably faster and more efficient.
🔬 Measurement: Verify by typing quickly into the search input. The markers and cards will only update after typing pauses, rather than updating continuously with each character.

---
*PR created automatically by Jules for task [3159341840702016895](https://jules.google.com/task/3159341840702016895) started by @divilella96*