### PR TITLE
🎨 Palette: Keyboard focus & screen reader utility classes

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-11-20 - Missing Utility Classes
+**Learning:** Found that accessibility-focused utility classes like `.visually-hidden` were being used in the HTML markup (`mensagem.html`) to hide screen reader text (`#status-announcer`) but were never actually defined in the shared CSS (`style.css`), meaning the text was visibly exposed or broken.
+**Action:** Always verify that utility classes referenced in markup are properly defined in the corresponding stylesheets, particularly those affecting accessibility visibility.

--- a/style.css
+++ b/style.css
@@ -125,6 +125,10 @@ button {
 
 button:hover { transform: translateY(-2px); }
 button:active { transform: translateY(0); }
+button:focus-visible, a:focus-visible {
+  outline: 3px solid var(--primary-color);
+  outline-offset: 2px;
+}
 
 form button {
   margin-top: 10px; /* Add space above buttons in forms */
@@ -223,4 +227,16 @@ form button {
 }
 .time-inputs > div {
     flex: 1;
+}
+
+/* Accessibility */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
 }


### PR DESCRIPTION
🎨 Palette UX enhancement: Adds vital accessibility fundamentals to the shared stylesheet.

💡 What: Added `:focus-visible` outlines for interactive elements and defined the `.visually-hidden` class.
🎯 Why: Keyboard users previously lacked visual feedback when navigating, and screen-reader-only elements like the ARIA status announcer were appearing visibly broken in the DOM because their utility class wasn't defined.
♿ Accessibility: Ensures interactive elements meet WCAG focus visibility requirements and properly hides off-screen text intended only for assistive technology.

---
*PR created automatically by Jules for task [2205552884416278977](https://jules.google.com/task/2205552884416278977) started by @divilella96*