### PR TITLE
⚡ Bolt: Add debounce to EMEL map search

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - [Debounce Frontend Map Search]
+**Learning:** Complex DOM updates and Leaflet map re-renders triggered by `onkeyup` events (like in `mapa_emel.html`) cause severe UI lag if fired on every keystroke. This is a crucial codebase-specific bottleneck because the map updates boundaries dynamically while searching a large local JSON dataset.
+**Action:** Always wrap event handlers that trigger complex DOM updates or map re-renders in a debounce function (e.g., `setTimeout` with ~300ms delay) to prevent blocking the main thread during typing.

--- a/mapa_emel.html
+++ b/mapa_emel.html
@@ -470,13 +470,18 @@
       renderCards(input);
     }
 
+    // ⚡ Bolt: Debounce search to prevent UI lag on every keystroke during map/card re-renders
+    let filterTimeout;
     function filterMap() {
-      const input = document.getElementById('streetInput').value.trim();
-      // On keyup we might just want to update the list, but maybe not the map zoom yet to avoid jumping?
-      // Let's update both for responsiveness.
-      const matches = filterData(input);
-      renderMarkers(matches); // This will zoom to fit bounds of matches
-      renderCards(input);
+      clearTimeout(filterTimeout);
+      filterTimeout = setTimeout(() => {
+        const input = document.getElementById('streetInput').value.trim();
+        // On keyup we might just want to update the list, but maybe not the map zoom yet to avoid jumping?
+        // Let's update both for responsiveness.
+        const matches = filterData(input);
+        renderMarkers(matches); // This will zoom to fit bounds of matches
+        renderCards(input);
+      }, 300); // 300ms debounce delay
     }
 
     // Initialize


### PR DESCRIPTION
💡 What: Added a 300ms debounce (`setTimeout`) to the `filterMap` function in `mapa_emel.html` to prevent it from executing on every keystroke.
🎯 Why: Complex DOM updates (re-rendering many cards) and Leaflet map boundary updates (`fitBounds`) were executing synchronously on every keystroke of the `onkeyup` event, causing severe main thread blocking and UI lag while typing in the search box.
📊 Impact: Eliminates typing lag by coalescing multiple rapid keystrokes into a single render pass.
🔬 Measurement: Verified using a Playwright script mimicking rapid sequential typing. Cards now update smoothly after typing stops.

---
*PR created automatically by Jules for task [5598894600605454314](https://jules.google.com/task/5598894600605454314) started by @divilella96*