### PR TITLE
⚡ Bolt: Add debounce to map filtering

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-05-24 - [Debounce Map Leaflet Rendering]
+**Learning:** In `mapa_emel.html`, the map search filtering functionality tied directly to the `keyup` event triggered an immediate Leaflet map bounds recalculation (`map.fitBounds`) and complex DOM manipulation (clearing and rebuilding DOM cards in `renderCards`). These heavy visual operations on every keystroke cause significant UI lag and jank.
+**Action:** When implementing or optimizing search/filter inputs that trigger Leaflet map updates or bulk DOM card creation, always wrap the event handlers in a debounce function (e.g., `setTimeout` with ~300ms delay) to batch the updates and prevent freezing the main thread.

--- a/mapa_emel.html
+++ b/mapa_emel.html
@@ -470,13 +470,18 @@
       renderCards(input);
     }
 
+    let filterTimeout;
     function filterMap() {
-      const input = document.getElementById('streetInput').value.trim();
-      // On keyup we might just want to update the list, but maybe not the map zoom yet to avoid jumping?
-      // Let's update both for responsiveness.
-      const matches = filterData(input);
-      renderMarkers(matches); // This will zoom to fit bounds of matches
-      renderCards(input);
+      clearTimeout(filterTimeout);
+      filterTimeout = setTimeout(() => {
+        const input = document.getElementById('streetInput').value.trim();
+        // On keyup we might just want to update the list, but maybe not the map zoom yet to avoid jumping?
+        // Let's update both for responsiveness.
+        // Performance optimization: Debounced to prevent Leaflet map re-renders and DOM updates on every keystroke
+        const matches = filterData(input);
+        renderMarkers(matches); // This will zoom to fit bounds of matches
+        renderCards(input);
+      }, 300);
     }
 
     // Initialize


### PR DESCRIPTION
💡 **What**: Added a 300ms debounce to the map filtering logic (`filterMap`) in `mapa_emel.html`.
🎯 **Why**: The previous implementation triggered a Leaflet map bounds recalculation and complex DOM recreation (clearing and rendering multiple result cards) on every single keystroke. This blocks the main thread and causes UI lag/jank while the user types.
📊 **Impact**: Prevents costly DOM operations and Leaflet repaints during fast typing, improving the search responsiveness and reducing the number of unnecessary computational cycles. The map only re-renders when the user finishes typing or pauses for 300ms.
🔬 **Measurement**: Verify by typing rapidly in the "Digite o nome da rua ou Código Postal..." input on the `mapa_emel.html` page. The map and cards should only update once you pause typing, instead of stuttering on every keypress.

---
*PR created automatically by Jules for task [12303290404820190958](https://jules.google.com/task/12303290404820190958) started by @divilella96*