### PR TITLE
⚡ Bolt: Add 300ms debounce to mapa_emel.html search filter

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-03-24 - [Debounce Leaflet re-renders to prevent main thread blocking]
+**Learning:** In a vanilla JS stack, triggering map boundary re-calculation and marker drawing via an external library like Leaflet directly on `keyup` for search inputs results in significant UI lag, blocking the main thread during typing because the computation completes synchronously on each stroke.
+**Action:** Always wrap event handlers that trigger complex DOM updates or map library rendering loops in a debounce block (`setTimeout`) to reduce execution frequency and preserve typing fluidity.

--- a/mapa_emel.html
+++ b/mapa_emel.html
@@ -470,13 +470,24 @@
       renderCards(input);
     }
 
+    let filterTimeout; // Added for debouncing
+
     function filterMap() {
-      const input = document.getElementById('streetInput').value.trim();
-      // On keyup we might just want to update the list, but maybe not the map zoom yet to avoid jumping?
-      // Let's update both for responsiveness.
-      const matches = filterData(input);
-      renderMarkers(matches); // This will zoom to fit bounds of matches
-      renderCards(input);
+      // ⚡ Bolt Performance Optimization:
+      // Debounce the map filtering to prevent UI lag.
+      // Leaflet map re-renders (renderMarkers) and DOM updates (renderCards)
+      // are expensive and block the main thread if fired on every single keystroke.
+      // This waits 300ms after the last keystroke before executing.
+      clearTimeout(filterTimeout);
+
+      filterTimeout = setTimeout(() => {
+        const input = document.getElementById('streetInput').value.trim();
+        // On keyup we might just want to update the list, but maybe not the map zoom yet to avoid jumping?
+        // Let's update both for responsiveness.
+        const matches = filterData(input);
+        renderMarkers(matches); // This will zoom to fit bounds of matches
+        renderCards(input);
+      }, 300);
     }
 
     // Initialize


### PR DESCRIPTION
💡 What: Implemented a 300ms debounce block using `setTimeout` and `clearTimeout` on the `filterMap` function triggered by the search input `keyup` event.

🎯 Why: The previous implementation fired heavy DOM updates (re-drawing Leaflet map boundaries, parsing JSON data, and re-rendering DOM cards) synchronously on every keystroke, which blocked the main thread and caused noticeable UI typing lag.

📊 Impact: Significantly improves typing responsiveness and fluidity in the search bar, reducing unnecessary DOM recalculations and layout thrashing by grouping fast keystrokes into a single execution context.

🔬 Measurement: Tested via a Playwright script mimicking rapid keystrokes (`press_sequentially`); the map and DOM now properly delay their updates until typing pauses, rather than freezing the browser on every letter.

---
*PR created automatically by Jules for task [8535299656486250217](https://jules.google.com/task/8535299656486250217) started by @divilella96*