### PR TITLE
🎨 Palette: Improve form validation with inline feedback

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,10 +1,3 @@
-## 2026-05-22 - Missing Accessibility Utility Classes
-**Learning:** Invanilla HTML/CSS projects, utility classes like `.visually-hidden` must be manually defined in the stylesheet. Simply adding them to the HTML is insufficient and will result in screen reader text becoming visible on the screen.
-**Action:** Always ensure that when using utility classes for accessibility (like `.visually-hidden`) or state (like `:focus-visible`), their definitions are explicitly added to the global `style.css`.
-
-## 2024-05-21 - [Accessibility] Missing utility classes
-**Learning:** Found elements in the DOM with classes like `.visually-hidden` that were not actually defined in the stylesheet. This causes elements meant only for screen readers to visibly render on screen, creating confusion.
-**Action:** Always verify that utility classes referenced in HTML actually exist in the CSS file, and consider standardizing a base set of accessibility classes for every project.
-## 2024-11-20 - Missing Utility Classes
-**Learning:** Found that accessibility-focused utility classes like `.visually-hidden` were being used in the HTML markup (`mensagem.html`) to hide screen reader text (`#status-announcer`) but were never actually defined in the shared CSS (`style.css`), meaning the text was visibly exposed or broken.
-**Action:** Always verify that utility classes referenced in markup are properly defined in the corresponding stylesheets, particularly those affecting accessibility visibility.
+## 2026-05-28 - Replace Blocking Alerts with Accessible Inline Validation
+**Learning:** Using native browser `alert()` for form validation creates a blocking, disruptive user experience and lacks necessary accessibility context.
+**Action:** Replace `alert()` with inline validation using a dedicated error container that employs `aria-live='polite'` to announce errors to screen readers, and update the input field with `aria-invalid='true'` while maintaining visible text errors.

--- a/aviso_atraso.html
+++ b/aviso_atraso.html
@@ -39,6 +39,7 @@
     <form onsubmit="return false;">
       <label for="phones">Números de Telefone</label>
       <textarea id="phones" placeholder="Insira os números de telefone (separados por vírgula ou nova linha). Ex: 912345678, 961234567"></textarea>
+      <small id="phones-error" style="color:red; display:none; margin-top:5px; font-weight:500;" aria-live="polite"></small>
 
       <label for="time">Hora Prevista de Entrega</label>
       <input type="time" id="time" value="13:30">
@@ -54,16 +55,23 @@
 
   <script>
     function showOptions() {
-      const phonesInput = document.getElementById('phones').value;
+      const phonesElement = document.getElementById('phones');
+      const phonesInput = phonesElement.value;
       const timeInput = document.getElementById('time').value;
       const resultsDiv = document.getElementById('results');
       const linksList = document.getElementById('linksList');
+      const phonesError = document.getElementById('phones-error');
 
-      // Clear previous results
+      // Clear previous results and errors
       linksList.innerHTML = '';
+      phonesError.style.display = 'none';
+      phonesElement.removeAttribute('aria-invalid');
 
       if (!phonesInput.trim()) {
-        alert("Por favor, insira pelo menos um número de telefone.");
+        phonesError.textContent = "⚠️ Por favor, insira pelo menos um número de telefone.";
+        phonesError.style.display = 'block';
+        phonesElement.setAttribute('aria-invalid', 'true');
+        phonesElement.focus();
         return;
       }
 
@@ -72,7 +80,10 @@
       const phones = phonesInput.split(/[\n,;]+/).map(p => p.trim()).filter(p => p !== '');
 
       if (phones.length === 0) {
-        alert("Nenhum número válido encontrado.");
+        phonesError.textContent = "⚠️ Nenhum número válido encontrado.";
+        phonesError.style.display = 'block';
+        phonesElement.setAttribute('aria-invalid', 'true');
+        phonesElement.focus();
         return;
       }
 


### PR DESCRIPTION
**💡 What:** 
Replaced blocking native browser `alert()` dialogs with accessible, inline text validation in `aviso_atraso.html`.

**🎯 Why:**
Native `alert()` calls disrupt the user flow, block the main thread, and lack context. Inline validation allows the user to correct their input without losing context.

**📸 Before/After:**
- *Before:* A standard browser alert pops up stating "Por favor, insira pelo menos um número de telefone.".
- *After:* A red text error appears directly below the textarea reading "⚠️ Por favor, insira pelo menos um número de telefone.", and the field regains focus.

**♿ Accessibility:**
- Added `aria-live="polite"` to the new error container to ensure screen readers announce the validation feedback.
- Dynamically toggle `aria-invalid="true"` on the textarea when an error occurs, providing state context to assistive technologies.

---
*PR created automatically by Jules for task [12019762520706161519](https://jules.google.com/task/12019762520706161519) started by @divilella96*