### PR TITLE
🎨 Palette: [UX improvement] Replace alert with inline validation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,6 @@
 ## 2024-11-20 - Missing Utility Classes
 **Learning:** Found that accessibility-focused utility classes like `.visually-hidden` were being used in the HTML markup (`mensagem.html`) to hide screen reader text (`#status-announcer`) but were never actually defined in the shared CSS (`style.css`), meaning the text was visibly exposed or broken.
 **Action:** Always verify that utility classes referenced in markup are properly defined in the corresponding stylesheets, particularly those affecting accessibility visibility.
+## 2024-05-23 - Inline Form Validation UX
+**Learning:** Found that using native browser `alert()` dialogs for form validation is disruptive, blocks the main thread, and creates a poor, inaccessible experience for screen reader users.
+**Action:** Always prefer accessible inline error feedback using `aria-live="polite"`, `aria-invalid`, and `aria-describedby` over blocking native browser `alert()` calls. This improves usability by providing contextual feedback without interrupting the user's flow.

--- a/aviso_atraso.html
+++ b/aviso_atraso.html
@@ -38,7 +38,8 @@
 
     <form onsubmit="return false;">
       <label for="phones">Números de Telefone</label>
-      <textarea id="phones" placeholder="Insira os números de telefone (separados por vírgula ou nova linha). Ex: 912345678, 961234567"></textarea>
+      <textarea id="phones" placeholder="Insira os números de telefone (separados por vírgula ou nova linha). Ex: 912345678, 961234567" aria-describedby="phones-error"></textarea>
+      <div id="phones-error" class="error-message" role="alert" aria-live="polite" style="color: #dc3545; display: none; font-size: 0.9em; margin-top: 5px;"></div>
 
       <label for="time">Hora Prevista de Entrega</label>
       <input type="time" id="time" value="13:30">
@@ -54,16 +55,24 @@
 
   <script>
     function showOptions() {
-      const phonesInput = document.getElementById('phones').value;
+      const phonesEl = document.getElementById('phones');
+      const phonesInput = phonesEl.value;
+      const errorEl = document.getElementById('phones-error');
       const timeInput = document.getElementById('time').value;
       const resultsDiv = document.getElementById('results');
       const linksList = document.getElementById('linksList');
 
-      // Clear previous results
+      // Clear previous results and errors
       linksList.innerHTML = '';
+      errorEl.style.display = 'none';
+      errorEl.textContent = '';
+      phonesEl.removeAttribute('aria-invalid');
 
       if (!phonesInput.trim()) {
-        alert("Por favor, insira pelo menos um número de telefone.");
+        errorEl.textContent = "Por favor, insira pelo menos um número de telefone.";
+        errorEl.style.display = 'block';
+        phonesEl.setAttribute('aria-invalid', 'true');
+        phonesEl.focus();
         return;
       }
 
@@ -72,7 +81,10 @@
       const phones = phonesInput.split(/[\n,;]+/).map(p => p.trim()).filter(p => p !== '');
 
       if (phones.length === 0) {
-        alert("Nenhum número válido encontrado.");
+        errorEl.textContent = "Nenhum número válido encontrado.";
+        errorEl.style.display = 'block';
+        phonesEl.setAttribute('aria-invalid', 'true');
+        phonesEl.focus();
         return;
       }
 


### PR DESCRIPTION
💡 **What:** Replaced the disruptive native browser `alert()` dialogs in the "Avisar Cliente sobre Atraso" form with an inline validation error message.
🎯 **Why:** Native alerts block the main thread, are disruptive to the user flow, and can be inaccessible or confusing for screen reader users. Inline feedback provides immediate, contextual error states.
📸 **Before/After:** Before, submitting empty fields spawned a blocking browser popup. After, a red text warning appears below the input, and the input itself is marked invalid.
♿ **Accessibility:** Added `aria-live="polite"` to the error container to announce errors dynamically, `aria-describedby` to link the input and error, and `aria-invalid="true"` when the input fails validation. Focus is also correctly returned to the input for correction.

---
*PR created automatically by Jules for task [3797533551861614584](https://jules.google.com/task/3797533551861614584) started by @divilella96*