### PR TITLE
⚡ Bolt: Cache Tesseract.js worker instance for faster OCR

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -10,3 +10,6 @@
 ## 2024-05-27 - [Debounce implementation Syntax Checks]
 **Learning:** In vanilla HTML/JS environments without build tools, applying debouncing or performance optimizations can easily introduce syntax errors (like duplicate function declarations or missing brackets) that silently fail in the browser or block functionality entirely.
 **Action:** Always verify inline JavaScript performance fixes (like debouncing) using `node -c` on extracted scripts or automated frontend verification (Playwright) to ensure the optimization doesn't introduce syntax errors.
+## 2024-05-29 - [Cache Tesseract.js Worker Instance]
+**Learning:** Found a specific performance bottleneck in `mensagem.html` where client-side OCR was unnecessarily slow for subsequent image uploads because `Tesseract.createWorker()` was called and `.terminate()` was executed on every operation. This caused massive redundant overhead by repeatedly loading WebAssembly binaries and initializing the worker thread.
+**Action:** Always initialize heavy WebWorkers (like Tesseract.js) globally and reuse the instance across operations, intentionally omitting `.terminate()` unless the page lifecycle is ending, to drastically improve performance on repeated use.

--- a/mensagem.html
+++ b/mensagem.html
@@ -257,6 +257,7 @@ Ticket: ${ticket}`;
     const btnExtrair6 = document.getElementById("btn-extrair-6");
 
     let extractedData = null;
+    let globalTesseractWorker = null; // ⚡ Bolt: Cache Tesseract worker instance
 
     imagemInput.addEventListener("change", async function(e) {
       if (e.target.files.length === 0) return;
@@ -267,13 +268,16 @@ Ticket: ${ticket}`;
       extractedData = null;
 
       try {
-        const worker = await Tesseract.createWorker('por', 1, {
-            workerPath: 'https://cdn.jsdelivr.net/npm/tesseract.js@5/dist/worker.min.js',
-            corePath: 'https://cdn.jsdelivr.net/npm/tesseract.js-core@5/tesseract-core.wasm.js'
-        });
-        const ret = await worker.recognize(file);
+        // ⚡ Bolt: Initialize once and reuse to prevent redundant WebAssembly loading
+        if (!globalTesseractWorker) {
+          globalTesseractWorker = await Tesseract.createWorker('por', 1, {
+              workerPath: 'https://cdn.jsdelivr.net/npm/tesseract.js@5/dist/worker.min.js',
+              corePath: 'https://cdn.jsdelivr.net/npm/tesseract.js-core@5/tesseract-core.wasm.js'
+          });
+        }
+        const ret = await globalTesseractWorker.recognize(file);
         const text = ret.data.text;
-        await worker.terminate();
+        // ⚡ Bolt: Removed worker.terminate() to keep instance alive for next use
 
         console.log("Texto extraído:", text);
 


### PR DESCRIPTION
💡 **What:** Introduced a `globalTesseractWorker` variable to cache the Tesseract.js worker instance globally in `mensagem.html`. Removed the `worker.terminate()` call at the end of the operation.

🎯 **Why:** Previously, the application created and terminated a new Tesseract Web Worker on every single image upload. This is an extremely expensive operation, as it requires re-downloading/loading the WebAssembly core, re-initializing the worker thread, and loading language data every time a new image was analyzed.

📊 **Impact:** Massive reduction in latency for subsequent OCR operations. The first image upload remains the same, but the second, third, etc. uploads will be processed significantly faster since the WebWorker is already fully initialized and waiting in memory.

🔬 **Measurement:** Upload an image with tracking numbers in `mensagem.html`. Time how long it takes to process. Then upload a second image. Notice that the second image processes almost instantly compared to the first, as the WebAssembly overhead has been completely eliminated.

---
*PR created automatically by Jules for task [8304024276824600407](https://jules.google.com/task/8304024276824600407) started by @divilella96*