### PR TITLE
🎨 Palette: Improve accessible inline error feedback for Encomenda field

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,6 @@
 ## 2024-11-20 - Missing Utility Classes
 **Learning:** Found that accessibility-focused utility classes like `.visually-hidden` were being used in the HTML markup (`mensagem.html`) to hide screen reader text (`#status-announcer`) but were never actually defined in the shared CSS (`style.css`), meaning the text was visibly exposed or broken.
 **Action:** Always verify that utility classes referenced in markup are properly defined in the corresponding stylesheets, particularly those affecting accessibility visibility.
+## 2024-05-30 - Accessible Inline Validation
+**Learning:** When dealing with dynamic form validation in vanilla HTML/JS, simply showing/hiding an error message visually (`style.display`) is insufficient for screen readers. Connecting the input to the error via `aria-describedby` and using `aria-live="polite"` on the error container, along with dynamically toggling `aria-invalid` on the input element itself, ensures that all users immediately understand when an input fails validation.
+**Action:** Always implement this `aria-invalid` / `aria-describedby` / `aria-live` triad when building custom inline form validation instead of relying solely on visual cues or the native `alert()`.

--- a/contact.html
+++ b/contact.html
@@ -13,8 +13,8 @@
 
     <form id="contactForm">
       <label for="encomenda">Número da Encomenda</label>
-      <input type="tel" id="encomenda" name="encomenda" placeholder="Ex: 00035625 / 530729" required inputmode="numeric">
-      <small id="erro-encomenda" style="color:red; display:none;">
+      <input type="tel" id="encomenda" name="encomenda" placeholder="Ex: 00035625 / 530729" required inputmode="numeric" aria-describedby="erro-encomenda">
+      <small id="erro-encomenda" style="color:red; display:none;" aria-live="polite">
       ⚠️ O número após a barra deve ter exatamente 6 dígitos.
       </small>
 
@@ -128,6 +128,7 @@
     // Máscara para o campo "Encomenda"
     document.getElementById("encomenda").addEventListener("input", function(e) {
       let valor = e.target.value.replace(/[^0-9/]/g, "");
+      const erro = document.getElementById("erro-encomenda");
       if (valor.includes("/")) {
         let [antes, depois] = valor.split("/");
         antes = antes.trim();
@@ -137,10 +138,16 @@
         if (depois.length === 6) {
           erro.style.display = "none";
           e.target.setCustomValidity("");
+          e.target.setAttribute("aria-invalid", "false");
         } else {
           erro.style.display = "block";
           e.target.setCustomValidity("O número após a barra deve ter exatamente 6 dígitos.");
+          e.target.setAttribute("aria-invalid", "true");
         }
+      } else {
+        e.target.removeAttribute("aria-invalid");
+        erro.style.display = "none";
+        e.target.setCustomValidity("");
       }
       e.target.value = valor;
     });

--- a/mensagem.html
+++ b/mensagem.html
@@ -39,8 +39,9 @@
         placeholder="Ex: 00035625 / 530729"
         required
         inputmode="numeric"
+        aria-describedby="erro-encomenda"
       />
-      <small id="erro-encomenda" style="color:red; display:none;">
+      <small id="erro-encomenda" style="color:red; display:none;" aria-live="polite">
       ⚠️ O número após a barra deve ter exatamente 6 dígitos.
       </small>
 
@@ -241,10 +242,16 @@ Ticket: ${ticket}`;
         if (depois.length === 6) {
             erro.style.display = "none";
             campoEncomenda.setCustomValidity("");
+            campoEncomenda.setAttribute("aria-invalid", "false");
         } else {
             erro.style.display = "block";
             campoEncomenda.setCustomValidity("O número após a barra deve ter exatamente 6 dígitos.");
+            campoEncomenda.setAttribute("aria-invalid", "true");
         }
+        } else {
+            campoEncomenda.removeAttribute("aria-invalid");
+            erro.style.display = "none";
+            campoEncomenda.setCustomValidity("");
         }
         e.target.value = valor;
     });


### PR DESCRIPTION
💡 **What:** Added comprehensive ARIA attributes (`aria-describedby`, `aria-live="polite"`, and dynamic `aria-invalid`) to the form validation for the 'Encomenda' inputs in both `contact.html` and `mensagem.html`. It also includes a small JS fix to properly clear the invalid state when the user corrects their input.

🎯 **Why:** Previously, the validation errors (e.g. 'O número após a barra deve ter exatamente 6 dígitos.') were only shown visually via CSS `display: block`. Screen reader users had no way of knowing their input was invalid or what the error message was, causing severe usability issues for visually impaired users trying to submit support tickets. 

📸 **Before/After:** Visually identical. Under the hood, screen readers will now read: "O número após a barra deve ter exatamente 6 dígitos."

♿ **Accessibility:**
- Added `aria-describedby` to programmatically link the input to the error message text.
- Added `aria-live="polite"` to the error container so that screen readers announce the text immediately when it appears without interrupting the user.
- Added dynamic toggling of the `aria-invalid` attribute via JavaScript to let the screen reader know the specific input field is in an invalid state.

---
*PR created automatically by Jules for task [13192617723193147022](https://jules.google.com/task/13192617723193147022) started by @divilella96*