### PR TITLE
🎨 Palette: [Inline error validation for form]

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,6 @@
 ## 2024-11-20 - Missing Utility Classes
 **Learning:** Found that accessibility-focused utility classes like `.visually-hidden` were being used in the HTML markup (`mensagem.html`) to hide screen reader text (`#status-announcer`) but were never actually defined in the shared CSS (`style.css`), meaning the text was visibly exposed or broken.
 **Action:** Always verify that utility classes referenced in markup are properly defined in the corresponding stylesheets, particularly those affecting accessibility visibility.
+## 2024-06-01 - Blocking Alerts Replace with Inline Accessible Validation
+**Learning:** The use of blocking `alert()` calls for form validation creates a disruptive user experience, especially for screen readers which may lose focus context.
+**Action:** Replace `alert()` calls with inline validation messages linked to inputs via `aria-describedby`, wrapping the error message in an `aria-live="polite"` container, and dynamically toggling `aria-invalid` while returning focus to the invalid field.

--- a/aviso_atraso.html
+++ b/aviso_atraso.html
@@ -38,7 +38,8 @@
 
     <form onsubmit="return false;">
       <label for="phones">Números de Telefone</label>
-      <textarea id="phones" placeholder="Insira os números de telefone (separados por vírgula ou nova linha). Ex: 912345678, 961234567"></textarea>
+      <textarea id="phones" placeholder="Insira os números de telefone (separados por vírgula ou nova linha). Ex: 912345678, 961234567" aria-describedby="phones-error"></textarea>
+      <small id="phones-error" style="color:red; display:none;" aria-live="polite"></small>
 
       <label for="time">Hora Prevista de Entrega</label>
       <input type="time" id="time" value="13:30">
@@ -54,16 +55,21 @@
 
   <script>
     function showOptions() {
-      const phonesInput = document.getElementById('phones').value;
+      const phonesElement = document.getElementById('phones');
+      const phonesInput = phonesElement.value;
       const timeInput = document.getElementById('time').value;
       const resultsDiv = document.getElementById('results');
       const linksList = document.getElementById('linksList');
+      const errorElement = document.getElementById('phones-error');
 
       // Clear previous results
       linksList.innerHTML = '';
 
       if (!phonesInput.trim()) {
-        alert("Por favor, insira pelo menos um número de telefone.");
+        errorElement.innerText = "Por favor, insira pelo menos um número de telefone.";
+        errorElement.style.display = 'block';
+        phonesElement.setAttribute('aria-invalid', 'true');
+        phonesElement.focus();
         return;
       }
 
@@ -72,9 +78,16 @@
       const phones = phonesInput.split(/[\n,;]+/).map(p => p.trim()).filter(p => p !== '');
 
       if (phones.length === 0) {
-        alert("Nenhum número válido encontrado.");
+        errorElement.innerText = "Nenhum número válido encontrado.";
+        errorElement.style.display = 'block';
+        phonesElement.setAttribute('aria-invalid', 'true');
+        phonesElement.focus();
         return;
       }
+
+      // Clear any previous errors
+      errorElement.style.display = 'none';
+      phonesElement.setAttribute('aria-invalid', 'false');
 
       // Construct Message
       // Template: "Olá! Pedimos desculpa pelo ligeiro atraso, mas acreditamos que a sua encomenda será entregue antes das {{HORA}}. Já está a ser priorizada assim que o motorista iniciar a próxima rota. Equipa Pingo Doce Online"


### PR DESCRIPTION
**💡 What:** Replaced the two blocking `alert()` calls in `aviso_atraso.html` with a semantic, accessible inline validation message.
**🎯 Why:** Browser `alert()` dialogs create a jarring UX that breaks flow and can be especially problematic for screen readers, often causing them to lose context. Inline validation is the modern standard for form UX.
**📸 Before/After:** Before, empty submission spawned a blocking JS alert. After, the form displays a red `Por favor, insira pelo menos um número de telefone.` inline message below the input.
**♿ Accessibility:** Added `aria-describedby` to the input, wrapped the error in an `aria-live="polite"` element, dynamically toggled `aria-invalid="true"/"false"`, and explicitly returned focus to the input (`.focus()`) on failure to ensure keyboard users aren't left stranded.

---
*PR created automatically by Jules for task [2065565642761709275](https://jules.google.com/task/2065565642761709275) started by @divilella96*