### PR TITLE
🎨 Palette: Improve accessible inline validation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,7 @@
 ## 2024-11-20 - Missing Utility Classes
 **Learning:** Found that accessibility-focused utility classes like `.visually-hidden` were being used in the HTML markup (`mensagem.html`) to hide screen reader text (`#status-announcer`) but were never actually defined in the shared CSS (`style.css`), meaning the text was visibly exposed or broken.
 **Action:** Always verify that utility classes referenced in markup are properly defined in the corresponding stylesheets, particularly those affecting accessibility visibility.
+
+## 2024-05-23 - Screen-reader disconnected inline errors
+**Learning:** Found dynamically displayed inline validation error messages (like `<small id="erro-encomenda">`) that appeared visually but lacked ARIA connection (`aria-describedby`) or screen-reader notification (`aria-live`, `aria-invalid`). This leaves non-visual users unaware of form validation issues.
+**Action:** When implementing inline form validation, always connect the input to the error container via `aria-describedby`, use `aria-live="polite"` on the error text element, and dynamically toggle `aria-invalid="true"` on the input via JavaScript when validation fails.

--- a/contact.html
+++ b/contact.html
@@ -13,8 +13,8 @@
 
     <form id="contactForm">
       <label for="encomenda">Número da Encomenda</label>
-      <input type="tel" id="encomenda" name="encomenda" placeholder="Ex: 00035625 / 530729" required inputmode="numeric">
-      <small id="erro-encomenda" style="color:red; display:none;">
+      <input type="tel" id="encomenda" name="encomenda" placeholder="Ex: 00035625 / 530729" required inputmode="numeric" aria-describedby="erro-encomenda">
+      <small id="erro-encomenda" aria-live="polite" style="color:red; display:none;">
       ⚠️ O número após a barra deve ter exatamente 6 dígitos.
       </small>
 
@@ -128,6 +128,8 @@
     // Máscara para o campo "Encomenda"
     document.getElementById("encomenda").addEventListener("input", function(e) {
       let valor = e.target.value.replace(/[^0-9/]/g, "");
+      const erro = document.getElementById("erro-encomenda");
+
       if (valor.includes("/")) {
         let [antes, depois] = valor.split("/");
         antes = antes.trim();
@@ -137,9 +139,11 @@
         if (depois.length === 6) {
           erro.style.display = "none";
           e.target.setCustomValidity("");
+          e.target.removeAttribute("aria-invalid");
         } else {
           erro.style.display = "block";
           e.target.setCustomValidity("O número após a barra deve ter exatamente 6 dígitos.");
+          e.target.setAttribute("aria-invalid", "true");
         }
       }
       e.target.value = valor;

--- a/mensagem.html
+++ b/mensagem.html
@@ -39,8 +39,9 @@
         placeholder="Ex: 00035625 / 530729"
         required
         inputmode="numeric"
+        aria-describedby="erro-encomenda"
       />
-      <small id="erro-encomenda" style="color:red; display:none;">
+      <small id="erro-encomenda" aria-live="polite" style="color:red; display:none;">
       ⚠️ O número após a barra deve ter exatamente 6 dígitos.
       </small>
 
@@ -241,9 +242,11 @@ Ticket: ${ticket}`;
         if (depois.length === 6) {
             erro.style.display = "none";
             campoEncomenda.setCustomValidity("");
+            campoEncomenda.removeAttribute("aria-invalid");
         } else {
             erro.style.display = "block";
             campoEncomenda.setCustomValidity("O número após a barra deve ter exatamente 6 dígitos.");
+            campoEncomenda.setAttribute("aria-invalid", "true");
         }
         }
         e.target.value = valor;


### PR DESCRIPTION
**What:**
Added accessible inline form validation to `mensagem.html` and `contact.html`. 
Also fixed a `ReferenceError` bug in `contact.html` caused by relying on an implicit global variable generated by an HTML ID.

**Why:**
Previously, the inline validation error ("O número após a barra deve ter exatamente 6 dígitos.") was only visible visually. Screen readers were not notified when the validation state changed, nor were they made aware of the error text associated with the input.

**Before/After:**
*Before*: Error message appeared on screen, but input lacked ARIA attributes, leaving non-visual users unaware.
*After*: Inputs receive `aria-invalid="true"` when invalid, and are linked to the error message via `aria-describedby`. The error message container has `aria-live="polite"` to announce the text when it appears.

**Accessibility Improvements:**
- Screen reader users are now notified of invalid inputs immediately.
- The specific error text is associated with the input so it's read when focused.

---
*PR created automatically by Jules for task [5289535344626089272](https://jules.google.com/task/5289535344626089272) started by @divilella96*