### PR TITLE
⚡ Bolt: Reuse Tesseract worker

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -10,3 +10,6 @@
 ## 2024-05-27 - [Debounce implementation Syntax Checks]
 **Learning:** In vanilla HTML/JS environments without build tools, applying debouncing or performance optimizations can easily introduce syntax errors (like duplicate function declarations or missing brackets) that silently fail in the browser or block functionality entirely.
 **Action:** Always verify inline JavaScript performance fixes (like debouncing) using `node -c` on extracted scripts or automated frontend verification (Playwright) to ensure the optimization doesn't introduce syntax errors.
+## 2024-05-28 - [Reuse Tesseract.js Worker]
+**Learning:** Initializing a new Tesseract.js worker instance on every image upload (`Tesseract.createWorker()`) causes a massive performance bottleneck due to the repeated overhead of loading WebAssembly and language data, especially when `worker.terminate()` is called after each extraction.
+**Action:** Always store the Tesseract worker instance globally, initialize it lazily on the first request, and omit `worker.terminate()` to reuse the worker for subsequent operations, drastically reducing processing time for consecutive image OCR tasks.

--- a/mensagem.html
+++ b/mensagem.html
@@ -257,6 +257,7 @@ Ticket: ${ticket}`;
     const btnExtrair6 = document.getElementById("btn-extrair-6");
 
     let extractedData = null;
+    let tesseractWorker = null; // ⚡ Bolt: Store the worker globally to reuse it
 
     imagemInput.addEventListener("change", async function(e) {
       if (e.target.files.length === 0) return;
@@ -267,13 +268,17 @@ Ticket: ${ticket}`;
       extractedData = null;
 
       try {
-        const worker = await Tesseract.createWorker('por', 1, {
-            workerPath: 'https://cdn.jsdelivr.net/npm/tesseract.js@5/dist/worker.min.js',
-            corePath: 'https://cdn.jsdelivr.net/npm/tesseract.js-core@5/tesseract-core.wasm.js'
-        });
-        const ret = await worker.recognize(file);
+        // ⚡ Bolt: Reuse the Tesseract worker instance to avoid WebAssembly and language data reloading overhead on subsequent image uploads
+        if (!tesseractWorker) {
+          tesseractWorker = await Tesseract.createWorker('por', 1, {
+              workerPath: 'https://cdn.jsdelivr.net/npm/tesseract.js@5/dist/worker.min.js',
+              corePath: 'https://cdn.jsdelivr.net/npm/tesseract.js-core@5/tesseract-core.wasm.js'
+          });
+        }
+
+        const ret = await tesseractWorker.recognize(file);
         const text = ret.data.text;
-        await worker.terminate();
+        // ⚡ Bolt: Removed worker.terminate() to keep the worker alive for future uploads
 
         console.log("Texto extraído:", text);
 


### PR DESCRIPTION
💡 What: Lazily initialize and globally reuse the `Tesseract.js` worker instance, preventing it from being terminated after each use.
🎯 Why: Creating a new worker and calling `worker.terminate()` on every image upload caused severe performance bottlenecks because Tesseract had to download, parse, and initialize WebAssembly binaries and language datasets from scratch each time.
📊 Impact: Drastically reduces processing time for second and subsequent OCR operations (from potentially several seconds down to a fraction of a second) by keeping the WebAssembly instance and language models in memory.
🔬 Measurement: Verified manually using a Playwright script that uploads two images sequentially; the second upload processes noticeably faster without the initial `worker.recognize()` delay.

---
*PR created automatically by Jules for task [16045884759347279387](https://jules.google.com/task/16045884759347279387) started by @divilella96*