### PR TITLE
⚡ Bolt: Optimize Tesseract.js worker initialization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -10,3 +10,6 @@
 ## 2024-05-27 - [Debounce implementation Syntax Checks]
 **Learning:** In vanilla HTML/JS environments without build tools, applying debouncing or performance optimizations can easily introduce syntax errors (like duplicate function declarations or missing brackets) that silently fail in the browser or block functionality entirely.
 **Action:** Always verify inline JavaScript performance fixes (like debouncing) using `node -c` on extracted scripts or automated frontend verification (Playwright) to ensure the optimization doesn't introduce syntax errors.
+## 2024-05-29 - [Tesseract.js WebWorker Overhead]
+**Learning:** Found a critical performance bottleneck in the client-side OCR (`mensagem.html`) where `Tesseract.createWorker()` and `worker.terminate()` were called on every image upload. This repeatedly downloaded and initialized the WebAssembly core and language model, adding massive multi-second overhead to each scan.
+**Action:** Always instantiate Tesseract.js workers globally and reuse them across operations. Avoid calling `.terminate()` unless explicitly freeing memory, to preserve the loaded WASM core and significantly speed up subsequent OCR tasks.

--- a/mensagem.html
+++ b/mensagem.html
@@ -257,6 +257,7 @@ Ticket: ${ticket}`;
     const btnExtrair6 = document.getElementById("btn-extrair-6");
 
     let extractedData = null;
+    let tesseractWorker = null; // ⚡ Bolt: Global worker to avoid reloading WASM on every scan
 
     imagemInput.addEventListener("change", async function(e) {
       if (e.target.files.length === 0) return;
@@ -267,13 +268,16 @@ Ticket: ${ticket}`;
       extractedData = null;
 
       try {
-        const worker = await Tesseract.createWorker('por', 1, {
-            workerPath: 'https://cdn.jsdelivr.net/npm/tesseract.js@5/dist/worker.min.js',
-            corePath: 'https://cdn.jsdelivr.net/npm/tesseract.js-core@5/tesseract-core.wasm.js'
-        });
-        const ret = await worker.recognize(file);
+        if (!tesseractWorker) {
+          tesseractWorker = await Tesseract.createWorker('por', 1, {
+              workerPath: 'https://cdn.jsdelivr.net/npm/tesseract.js@5/dist/worker.min.js',
+              corePath: 'https://cdn.jsdelivr.net/npm/tesseract.js-core@5/tesseract-core.wasm.js'
+          });
+        }
+
+        const ret = await tesseractWorker.recognize(file);
         const text = ret.data.text;
-        await worker.terminate();
+        // ⚡ Bolt: Removed worker.terminate() so the loaded WASM core and language model can be reused
 
         console.log("Texto extraído:", text);
 


### PR DESCRIPTION
**💡 What:** 
Moved the `Tesseract.createWorker()` initialization in `mensagem.html` to instantiate a global `tesseractWorker` only once, and removed the `worker.terminate()` call.

**🎯 Why:** 
The previous implementation downloaded and loaded the Tesseract WebWorker, WebAssembly core, and Portuguese language model every single time an image was uploaded, and destroyed it immediately after. This was a massive performance bottleneck, causing multi-second delays for every OCR scan.

**📊 Impact:** 
Expected to reduce OCR processing time for all subsequent image uploads by >80%. Only the first upload will incur the WASM loading overhead.

**🔬 Measurement:** 
Open `mensagem.html`, select an image with text. Note the processing time. Select a second image. The second image should process almost instantaneously compared to the first, as the network and WASM initialization overhead is bypassed. You can also view the network tab in DevTools to confirm that worker files are not re-downloaded/initialized on the second upload.

---
*PR created automatically by Jules for task [6242269338579021125](https://jules.google.com/task/6242269338579021125) started by @divilella96*