### PR TITLE
🎨 Palette: Add accessible inline form validation to aviso_atraso.html

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,7 @@
 ## 2024-11-20 - Missing Utility Classes
 **Learning:** Found that accessibility-focused utility classes like `.visually-hidden` were being used in the HTML markup (`mensagem.html`) to hide screen reader text (`#status-announcer`) but were never actually defined in the shared CSS (`style.css`), meaning the text was visibly exposed or broken.
 **Action:** Always verify that utility classes referenced in markup are properly defined in the corresponding stylesheets, particularly those affecting accessibility visibility.
+
+## 2024-11-20 - [Accessibility] Replacing alert() with Accessible Inline Validation
+**Learning:** Found that form validation in `aviso_atraso.html` relied on blocking `alert()` calls, which provide a poor user experience and are not accessible to screen readers natively tied to the form field. The pattern for this app is to connect validation directly to inputs.
+**Action:** Always replace blocking `alert()` validation with polite inline error containers connected to the input via `aria-describedby` and dynamically toggle `aria-invalid="true"` while shifting focus (`.focus()`) to the invalid input.

--- a/aviso_atraso.html
+++ b/aviso_atraso.html
@@ -38,7 +38,8 @@
 
     <form onsubmit="return false;">
       <label for="phones">Números de Telefone</label>
-      <textarea id="phones" placeholder="Insira os números de telefone (separados por vírgula ou nova linha). Ex: 912345678, 961234567"></textarea>
+      <textarea id="phones" aria-invalid="false" aria-describedby="phones-error" placeholder="Insira os números de telefone (separados por vírgula ou nova linha). Ex: 912345678, 961234567" oninput="resetPhoneError()"></textarea>
+      <div id="phones-error" aria-live="polite" style="display:none; color:red; margin-top: 5px; margin-bottom: 15px; font-size: 0.9em;"></div>
 
       <label for="time">Hora Prevista de Entrega</label>
       <input type="time" id="time" value="13:30">
@@ -53,17 +54,31 @@
   </div>
 
   <script>
+    function resetPhoneError() {
+      const errorDiv = document.getElementById('phones-error');
+      const phonesInputEl = document.getElementById('phones');
+      errorDiv.style.display = 'none';
+      errorDiv.textContent = '';
+      phonesInputEl.setAttribute('aria-invalid', 'false');
+    }
+
     function showOptions() {
-      const phonesInput = document.getElementById('phones').value;
+      const phonesInputEl = document.getElementById('phones');
+      const phonesInput = phonesInputEl.value;
       const timeInput = document.getElementById('time').value;
       const resultsDiv = document.getElementById('results');
       const linksList = document.getElementById('linksList');
+      const errorDiv = document.getElementById('phones-error');
 
       // Clear previous results
       linksList.innerHTML = '';
+      resetPhoneError();
 
       if (!phonesInput.trim()) {
-        alert("Por favor, insira pelo menos um número de telefone.");
+        errorDiv.textContent = "Por favor, insira pelo menos um número de telefone.";
+        errorDiv.style.display = 'block';
+        phonesInputEl.setAttribute('aria-invalid', 'true');
+        phonesInputEl.focus();
         return;
       }
 
@@ -72,7 +87,10 @@
       const phones = phonesInput.split(/[\n,;]+/).map(p => p.trim()).filter(p => p !== '');
 
       if (phones.length === 0) {
-        alert("Nenhum número válido encontrado.");
+        errorDiv.textContent = "Nenhum número válido encontrado.";
+        errorDiv.style.display = 'block';
+        phonesInputEl.setAttribute('aria-invalid', 'true');
+        phonesInputEl.focus();
         return;
       }
 


### PR DESCRIPTION
💡 What: Replaced blocking `alert()` calls for form validation in `aviso_atraso.html` with an inline error message container.
🎯 Why: Browser `alert()` boxes provide a disruptive user experience and are not natively accessible to screen readers trying to understand the context of the invalid form field.
📸 Before/After: Before, an empty submission triggered an `alert()`. Now, it triggers an inline red text error message right below the field.
♿ Accessibility: Added `aria-invalid` state management, `aria-describedby` linking the error to the textarea, and `aria-live="polite"` on the error container to ensure screen readers announce the validation error gracefully while shifting `.focus()` to the invalid input.

---
*PR created automatically by Jules for task [16744332826933244754](https://jules.google.com/task/16744332826933244754) started by @divilella96*