### PR TITLE
🎨 Palette: Improve form validation with inline feedback

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,7 @@
 ## 2024-11-20 - Missing Utility Classes
 **Learning:** Found that accessibility-focused utility classes like `.visually-hidden` were being used in the HTML markup (`mensagem.html`) to hide screen reader text (`#status-announcer`) but were never actually defined in the shared CSS (`style.css`), meaning the text was visibly exposed or broken.
 **Action:** Always verify that utility classes referenced in markup are properly defined in the corresponding stylesheets, particularly those affecting accessibility visibility.
+
+## 2024-05-23 - Avoid blocking alerts for form validation
+**Learning:** The application was using blocking `alert()` calls for form validation (e.g., in `aviso_atraso.html`). This creates a jarring user experience and is inaccessible for screen reader users.
+**Action:** When implementing form validation, always prefer accessible inline feedback. Use a dedicated error container with `aria-live="polite"`, connect it to the input field using `aria-describedby`, and dynamically toggle the `aria-invalid` attribute on the input element.

--- a/aviso_atraso.html
+++ b/aviso_atraso.html
@@ -39,6 +39,7 @@
     <form onsubmit="return false;">
       <label for="phones">Números de Telefone</label>
       <textarea id="phones" placeholder="Insira os números de telefone (separados por vírgula ou nova linha). Ex: 912345678, 961234567"></textarea>
+      <div id="phones-error" style="color: red; display: none; margin-top: 5px; font-size: 0.9em;" aria-live="polite"></div>
 
       <label for="time">Hora Prevista de Entrega</label>
       <input type="time" id="time" value="13:30">
@@ -62,8 +63,28 @@
       // Clear previous results
       linksList.innerHTML = '';
 
+      const phonesElement = document.getElementById('phones');
+      const errorElement = document.getElementById('phones-error');
+
+      const showError = (msg) => {
+        errorElement.textContent = msg;
+        errorElement.style.display = 'block';
+        phonesElement.setAttribute('aria-invalid', 'true');
+        phonesElement.setAttribute('aria-describedby', 'phones-error');
+        phonesElement.focus();
+      };
+
+      const clearError = () => {
+        errorElement.style.display = 'none';
+        errorElement.textContent = '';
+        phonesElement.removeAttribute('aria-invalid');
+        phonesElement.removeAttribute('aria-describedby');
+      };
+
+      clearError();
+
       if (!phonesInput.trim()) {
-        alert("Por favor, insira pelo menos um número de telefone.");
+        showError("Por favor, insira pelo menos um número de telefone.");
         return;
       }
 
@@ -72,7 +93,7 @@
       const phones = phonesInput.split(/[\n,;]+/).map(p => p.trim()).filter(p => p !== '');
 
       if (phones.length === 0) {
-        alert("Nenhum número válido encontrado.");
+        showError("Nenhum número válido encontrado.");
         return;
       }
 


### PR DESCRIPTION
💡 **What**: Replaced blocking `alert()` calls in the `aviso_atraso.html` form with an inline validation message and ARIA attributes.
🎯 **Why**: Blocking alerts provide a poor user experience and are not accessible to all users. Using inline feedback provides immediate, contextual guidance without interrupting the flow, making it significantly more user-friendly.
📸 **Before/After**: Before, leaving the phone field empty and submitting triggered a native browser `alert()` modal. Now, it displays a red, inline error message directly below the textarea and sets focus back on the input.
♿ **Accessibility**: Added `aria-live="polite"` to the error container to notify screen readers, used `aria-describedby` to programmatically associate the error text with the input, and toggled `aria-invalid="true"` when an error is present. The focus is also explicitly set to the invalid input.

---
*PR created automatically by Jules for task [17988792508466803646](https://jules.google.com/task/17988792508466803646) started by @divilella96*