### PR TITLE
⚡ Bolt: Reuse Tesseract worker to improve OCR performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -10,3 +10,6 @@
 ## 2024-05-27 - [Debounce implementation Syntax Checks]
 **Learning:** In vanilla HTML/JS environments without build tools, applying debouncing or performance optimizations can easily introduce syntax errors (like duplicate function declarations or missing brackets) that silently fail in the browser or block functionality entirely.
 **Action:** Always verify inline JavaScript performance fixes (like debouncing) using `node -c` on extracted scripts or automated frontend verification (Playwright) to ensure the optimization doesn't introduce syntax errors.
+## 2024-05-29 - [Tesseract Worker Reuse]
+**Learning:** Initializing a Tesseract.js worker and calling `.terminate()` inside an event listener (like `change` for file inputs) causes significant overhead because the WebAssembly core and worker scripts are downloaded and compiled on every single execution.
+**Action:** Initialize the Tesseract.js worker once globally (lazily on first use) and reuse the instance for subsequent OCR operations. Do not call `.terminate()` unless the worker is completely unneeded, to eliminate redundant initialization overhead and drastically speed up consecutive operations.

--- a/mensagem.html
+++ b/mensagem.html
@@ -257,6 +257,7 @@ Ticket: ${ticket}`;
     const btnExtrair6 = document.getElementById("btn-extrair-6");
 
     let extractedData = null;
+    let tesseractWorker = null;
 
     imagemInput.addEventListener("change", async function(e) {
       if (e.target.files.length === 0) return;
@@ -267,13 +268,15 @@ Ticket: ${ticket}`;
       extractedData = null;
 
       try {
-        const worker = await Tesseract.createWorker('por', 1, {
-            workerPath: 'https://cdn.jsdelivr.net/npm/tesseract.js@5/dist/worker.min.js',
-            corePath: 'https://cdn.jsdelivr.net/npm/tesseract.js-core@5/tesseract-core.wasm.js'
-        });
-        const ret = await worker.recognize(file);
+        if (!tesseractWorker) {
+          // ⚡ Bolt: Cache Tesseract worker to avoid downloading WebAssembly/Worker on every upload
+          tesseractWorker = await Tesseract.createWorker('por', 1, {
+              workerPath: 'https://cdn.jsdelivr.net/npm/tesseract.js@5/dist/worker.min.js',
+              corePath: 'https://cdn.jsdelivr.net/npm/tesseract.js-core@5/tesseract-core.wasm.js'
+          });
+        }
+        const ret = await tesseractWorker.recognize(file);
         const text = ret.data.text;
-        await worker.terminate();
 
         console.log("Texto extraído:", text);
 


### PR DESCRIPTION
💡 What:
Initialized the Tesseract.js worker lazily and cached it globally instead of creating and terminating it on every image upload in `mensagem.html`.

🎯 Why:
The `Tesseract.createWorker` initialization (especially downloading and compiling WebAssembly cores and worker scripts) is an expensive operation. Previously, it occurred inside the `change` event listener for file uploads, meaning every consecutive image scan forced the browser to re-download/re-compile the worker, severely bottlenecking multi-scan performance.

📊 Impact:
Reduces OCR initialization time from multiple seconds to virtually zero for subsequent image uploads, dramatically improving UX for users processing multiple items.

🔬 Measurement:
1. Open `mensagem.html`.
2. Upload an image to scan. Note the time it takes to process.
3. Upload another image immediately after. The processing will be almost instant as the worker is already primed.

---
*PR created automatically by Jules for task [3714247522904304132](https://jules.google.com/task/3714247522904304132) started by @divilella96*