### PR TITLE
🎨 Palette: Improve accessible inline validation for Encomenda inputs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,7 @@
 ## 2024-11-20 - Missing Utility Classes
 **Learning:** Found that accessibility-focused utility classes like `.visually-hidden` were being used in the HTML markup (`mensagem.html`) to hide screen reader text (`#status-announcer`) but were never actually defined in the shared CSS (`style.css`), meaning the text was visibly exposed or broken.
 **Action:** Always verify that utility classes referenced in markup are properly defined in the corresponding stylesheets, particularly those affecting accessibility visibility.
+
+## 2024-11-20 - Accessible Inline Form Validation
+**Learning:** Found instances where form validation used unlinked visual text blocks to show errors (via `display: block` or `display: none`) and didn't convey the error state to screen readers.
+**Action:** For inline form validation, always link the error message element to the input field using `aria-describedby`, add `aria-live="polite"` to the error container, and dynamically toggle the `aria-invalid="true"` attribute on the input field via JavaScript when invalid.

--- a/contact.html
+++ b/contact.html
@@ -13,8 +13,8 @@
 
     <form id="contactForm">
       <label for="encomenda">Número da Encomenda</label>
-      <input type="tel" id="encomenda" name="encomenda" placeholder="Ex: 00035625 / 530729" required inputmode="numeric">
-      <small id="erro-encomenda" style="color:red; display:none;">
+      <input type="tel" id="encomenda" name="encomenda" placeholder="Ex: 00035625 / 530729" required inputmode="numeric" aria-describedby="erro-encomenda">
+      <small id="erro-encomenda" style="color:red; display:none;" aria-live="polite">
       ⚠️ O número após a barra deve ter exatamente 6 dígitos.
       </small>
 
@@ -126,7 +126,9 @@
     });
 
     // Máscara para o campo "Encomenda"
-    document.getElementById("encomenda").addEventListener("input", function(e) {
+    const campoEncomendaContact = document.getElementById("encomenda");
+    const erroContact = document.getElementById("erro-encomenda");
+    campoEncomendaContact.addEventListener("input", function(e) {
       let valor = e.target.value.replace(/[^0-9/]/g, "");
       if (valor.includes("/")) {
         let [antes, depois] = valor.split("/");
@@ -135,12 +137,17 @@
         valor = antes + " / " + depois;
 
         if (depois.length === 6) {
-          erro.style.display = "none";
+          erroContact.style.display = "none";
           e.target.setCustomValidity("");
+          e.target.removeAttribute("aria-invalid");
         } else {
-          erro.style.display = "block";
+          erroContact.style.display = "block";
           e.target.setCustomValidity("O número após a barra deve ter exatamente 6 dígitos.");
+          e.target.setAttribute("aria-invalid", "true");
         }
+      } else {
+        e.target.removeAttribute("aria-invalid");
+        erroContact.style.display = "none";
       }
       e.target.value = valor;
     });

--- a/mensagem.html
+++ b/mensagem.html
@@ -39,8 +39,9 @@
         placeholder="Ex: 00035625 / 530729"
         required
         inputmode="numeric"
+        aria-describedby="erro-encomenda"
       />
-      <small id="erro-encomenda" style="color:red; display:none;">
+      <small id="erro-encomenda" style="color:red; display:none;" aria-live="polite">
       ⚠️ O número após a barra deve ter exatamente 6 dígitos.
       </small>
 
@@ -241,10 +242,15 @@ Ticket: ${ticket}`;
         if (depois.length === 6) {
             erro.style.display = "none";
             campoEncomenda.setCustomValidity("");
+            campoEncomenda.removeAttribute("aria-invalid");
         } else {
             erro.style.display = "block";
             campoEncomenda.setCustomValidity("O número após a barra deve ter exatamente 6 dígitos.");
+            campoEncomenda.setAttribute("aria-invalid", "true");
         }
+        } else {
+            campoEncomenda.removeAttribute("aria-invalid");
+            erro.style.display = "none";
         }
         e.target.value = valor;
     });


### PR DESCRIPTION
**💡 What:** 
Improved the accessibility of inline form validation for the "Encomenda" input fields in both `contact.html` and `mensagem.html`.
- Added `aria-describedby` to inputs linking to the error `<small>` element.
- Added `aria-live="polite"` to the error `<small>` element so screen readers will announce the error when it appears.
- Updated the JavaScript validation logic to dynamically toggle `aria-invalid="true"` / `removeAttribute("aria-invalid")`.
- Fixed a bug in `contact.html` where `erro` was an implicit global relying on the DOM `id`, now formally declared.

**🎯 Why:**
Previously, the inline form validation relied on visually showing/hiding a text block (`display: block` / `none`). This visual cue was completely unlinked from the input itself, meaning a screen reader user tabbing through the form and making an error might never be informed that their input is invalid or what the error message says. This makes the form far more robust and accessible.

**📸 Before/After:**
*(Visuals remain unchanged, but accessibility tree exposes error state correctly now.)*

**♿ Accessibility:**
- `aria-describedby` creates a programmatic relationship between input and error text.
- `aria-live="polite"` ensures the newly shown error is announced.
- `aria-invalid` alerts screen reader users that their current input needs correction.

---
*PR created automatically by Jules for task [13899741637170945197](https://jules.google.com/task/13899741637170945197) started by @divilella96*