### PR TITLE
🎨 Palette: [UX improvement] Add aria-label to missing form inputs

### DIFF
--- a/comunicacao_bot.html
+++ b/comunicacao_bot.html
@@ -28,7 +28,7 @@
         <label>Encomendas</label>
         <div id="order-list">
           <div class="order-input-group">
-            <input type="text" class="order-input" placeholder="Número da encomenda" maxlength="6" pattern="[0-9]*" oninput="this.value = this.value.replace(/[^0-9]/g, '');">
+            <input type="text" class="order-input" placeholder="Número da encomenda" aria-label="Número da encomenda" maxlength="6" pattern="[0-9]*" oninput="this.value = this.value.replace(/[^0-9]/g, '');">
             <!-- First one typically doesn't have remove button unless we want to allow 0 orders, but usually at least 1 is needed.
                  Let's add remove button even for the first one for consistency, but maybe handle logic to not remove if it's the only one?
                  Or just let it be empty. -->
@@ -174,6 +174,7 @@
       input.type = 'text';
       input.className = 'order-input';
       input.placeholder = 'Número da encomenda';
+      input.setAttribute('aria-label', 'Número da encomenda');
       input.maxLength = 6;
       input.pattern = "[0-9]*";
       input.oninput = function() { this.value = this.value.replace(/[^0-9]/g, ''); };

--- a/mapa_emel.html
+++ b/mapa_emel.html
@@ -125,7 +125,7 @@
     <h1>Validação Mapa EMEL</h1>
 
     <div class="search-section">
-      <input type="text" id="streetInput" placeholder="Digite o nome da rua ou Código Postal..." onkeyup="filterMap()">
+      <input type="text" id="streetInput" placeholder="Digite o nome da rua ou Código Postal..." aria-label="Buscar rua ou código postal" onkeyup="filterMap()">
       <button class="btn-primary" onclick="validateStreet()">Validar</button>
       <button class="btn-secondary" onclick="window.close()">Fechar</button>
     </div>


### PR DESCRIPTION
💡 **What:** Added `aria-label` to text inputs that lacked explicit labels, relying only on placeholders.
🎯 **Why:** Placeholders are not recognized as accessible labels by screen readers, making it difficult for visually impaired users to understand what to enter.
📸 **Before/After:** The visual UI remains unchanged. The change happens in the DOM attributes.
♿ **Accessibility:** Added `aria-label="Buscar rua ou código postal"` to the search input in `mapa_emel.html`. Added `aria-label="Número da encomenda"` to both the static and dynamically generated order inputs in `comunicacao_bot.html`.

---
*PR created automatically by Jules for task [16824813595696367488](https://jules.google.com/task/16824813595696367488) started by @divilella96*