### PR TITLE
🎨 Palette: Add explicit aria-labels to input fields

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,7 @@
 ## 2024-11-20 - Missing Utility Classes
 **Learning:** Found that accessibility-focused utility classes like `.visually-hidden` were being used in the HTML markup (`mensagem.html`) to hide screen reader text (`#status-announcer`) but were never actually defined in the shared CSS (`style.css`), meaning the text was visibly exposed or broken.
 **Action:** Always verify that utility classes referenced in markup are properly defined in the corresponding stylesheets, particularly those affecting accessibility visibility.
+
+## 2024-05-18 - Missing Explicit Labels for Form Inputs
+**Learning:** Found that multiple vanilla HTML files (e.g., `mapa_emel.html`, `comunicacao_bot.html`) relied solely on visual `placeholder` text instead of using accessible `<label>` wrappers or explicit `aria-label` attributes for primary input fields. This negatively impacts screen reader users who miss context.
+**Action:** Always provide explicit `aria-label` attributes to text inputs (both static and dynamically generated via JS) when visible `<label>` wrappers are omitted for design reasons.

--- a/comunicacao_bot.html
+++ b/comunicacao_bot.html
@@ -28,7 +28,7 @@
         <label>Encomendas</label>
         <div id="order-list">
           <div class="order-input-group">
-            <input type="text" class="order-input" placeholder="Número da encomenda" maxlength="6" pattern="[0-9]*" oninput="this.value = this.value.replace(/[^0-9]/g, '');">
+            <input type="text" class="order-input" placeholder="Número da encomenda" aria-label="Número da encomenda" maxlength="6" pattern="[0-9]*" oninput="this.value = this.value.replace(/[^0-9]/g, '');">
             <!-- First one typically doesn't have remove button unless we want to allow 0 orders, but usually at least 1 is needed.
                  Let's add remove button even for the first one for consistency, but maybe handle logic to not remove if it's the only one?
                  Or just let it be empty. -->
@@ -174,6 +174,7 @@
       input.type = 'text';
       input.className = 'order-input';
       input.placeholder = 'Número da encomenda';
+      input.setAttribute('aria-label', 'Número da encomenda');
       input.maxLength = 6;
       input.pattern = "[0-9]*";
       input.oninput = function() { this.value = this.value.replace(/[^0-9]/g, ''); };

--- a/mapa_emel.html
+++ b/mapa_emel.html
@@ -125,7 +125,7 @@
     <h1>Validação Mapa EMEL</h1>
 
     <div class="search-section">
-      <input type="text" id="streetInput" placeholder="Digite o nome da rua ou Código Postal..." onkeyup="filterMap()">
+      <input type="text" id="streetInput" placeholder="Digite o nome da rua ou Código Postal..." aria-label="Procurar por rua ou código postal" onkeyup="filterMap()">
       <button class="btn-primary" onclick="validateStreet()">Validar</button>
       <button class="btn-secondary" onclick="window.close()">Fechar</button>
     </div>


### PR DESCRIPTION
💡 **What:** Added explicit `aria-label` attributes to the `#streetInput` in `mapa_emel.html` and the `.order-input`s (both static and dynamically generated) in `comunicacao_bot.html`.

🎯 **Why:** Multiple text inputs in this vanilla app relied solely on visual `placeholder` text to explain their purpose. Because they lacked a properly associated `<label>` or an `aria-label`, screen readers might have failed to announce their purpose, creating an inaccessible experience for users relying on assistive technology.

📸 **Before/After:** No visual changes. The modification occurs entirely at the DOM attribute level, so sighted users will see no difference, but screen reader users get a massively improved experience.

♿ **Accessibility:** Form fields now have explicit, native semantic context without requiring sweeping layout changes to accommodate visible label elements.

---
*PR created automatically by Jules for task [7710980795022908385](https://jules.google.com/task/7710980795022908385) started by @divilella96*