### PR TITLE
🎨 Palette: Add aria-labels to placeholder-only inputs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,7 @@
 ## 2024-11-20 - Missing Utility Classes
 **Learning:** Found that accessibility-focused utility classes like `.visually-hidden` were being used in the HTML markup (`mensagem.html`) to hide screen reader text (`#status-announcer`) but were never actually defined in the shared CSS (`style.css`), meaning the text was visibly exposed or broken.
 **Action:** Always verify that utility classes referenced in markup are properly defined in the corresponding stylesheets, particularly those affecting accessibility visibility.
+
+## 2024-05-18 - Missing labels on placeholder-only inputs
+**Learning:** Text inputs that rely solely on `placeholder` attributes (like `#streetInput` and `.order-input`) break screen reader accessibility, as placeholders are not reliably announced as labels.
+**Action:** Always provide an explicit `<label>` or add `aria-label` to inputs when visible labels are omitted for design reasons.

--- a/comunicacao_bot.html
+++ b/comunicacao_bot.html
@@ -28,7 +28,7 @@
         <label>Encomendas</label>
         <div id="order-list">
           <div class="order-input-group">
-            <input type="text" class="order-input" placeholder="Número da encomenda" maxlength="6" pattern="[0-9]*" oninput="this.value = this.value.replace(/[^0-9]/g, '');">
+            <input type="text" class="order-input" placeholder="Número da encomenda" aria-label="Número da encomenda" maxlength="6" pattern="[0-9]*" oninput="this.value = this.value.replace(/[^0-9]/g, '');">
             <!-- First one typically doesn't have remove button unless we want to allow 0 orders, but usually at least 1 is needed.
                  Let's add remove button even for the first one for consistency, but maybe handle logic to not remove if it's the only one?
                  Or just let it be empty. -->
@@ -174,6 +174,7 @@
       input.type = 'text';
       input.className = 'order-input';
       input.placeholder = 'Número da encomenda';
+      input.setAttribute('aria-label', 'Número da encomenda');
       input.maxLength = 6;
       input.pattern = "[0-9]*";
       input.oninput = function() { this.value = this.value.replace(/[^0-9]/g, ''); };

--- a/mapa_emel.html
+++ b/mapa_emel.html
@@ -125,7 +125,7 @@
     <h1>Validação Mapa EMEL</h1>
 
     <div class="search-section">
-      <input type="text" id="streetInput" placeholder="Digite o nome da rua ou Código Postal..." onkeyup="filterMap()">
+      <input type="text" id="streetInput" placeholder="Digite o nome da rua ou Código Postal..." aria-label="Procurar rua ou código postal" onkeyup="filterMap()">
       <button class="btn-primary" onclick="validateStreet()">Validar</button>
       <button class="btn-secondary" onclick="window.close()">Fechar</button>
     </div>


### PR DESCRIPTION
### 💡 What
Added explicit `aria-label` attributes to text inputs across the application that previously lacked `<label>` tags and relied entirely on `placeholder` text for context. 

Specifically:
- Added `aria-label="Procurar rua ou código postal"` to `#streetInput` in `mapa_emel.html`.
- Added `aria-label="Número da encomenda"` to the static and dynamically generated `.order-input` fields in `comunicacao_bot.html`.

### 🎯 Why
Placeholder text is not a reliable substitute for a `<label>`. Screen readers often ignore placeholders or announce them inconsistently, leaving users relying on assistive technologies without context for what the input requires. When visible labels are omitted for aesthetic or space-saving reasons, an `aria-label` must step in to provide that critical context. 

### 📸 Before/After
**Before:** Screen readers encountered `<input type="text" placeholder="Número da encomenda">` and might only announce "Edit text, blank".
**After:** Screen readers encounter the element and explicitly announce "Número da encomenda, edit text". 

### ♿ Accessibility
- Dramatically improved form accessibility for screen reader users by ensuring all inputs have a discernible name.
- Created an entry in `.Jules/palette.md` documenting this learning to prevent placeholder-only inputs from re-entering the codebase.

---
*PR created automatically by Jules for task [9421422531357767284](https://jules.google.com/task/9421422531357767284) started by @divilella96*