### PR TITLE
🎨 Palette: Melhoria de acessibilidade nos campos de pesquisa e inputs sem label

### DIFF
--- a/comunicacao_bot.html
+++ b/comunicacao_bot.html
@@ -28,7 +28,7 @@
         <label>Encomendas</label>
         <div id="order-list">
           <div class="order-input-group">
-            <input type="text" class="order-input" placeholder="Número da encomenda" maxlength="6" pattern="[0-9]*" oninput="this.value = this.value.replace(/[^0-9]/g, '');">
+            <input type="text" class="order-input" placeholder="Número da encomenda" aria-label="Número da encomenda" maxlength="6" pattern="[0-9]*" oninput="this.value = this.value.replace(/[^0-9]/g, '');">
             <!-- First one typically doesn't have remove button unless we want to allow 0 orders, but usually at least 1 is needed.
                  Let's add remove button even for the first one for consistency, but maybe handle logic to not remove if it's the only one?
                  Or just let it be empty. -->
@@ -174,6 +174,7 @@
       input.type = 'text';
       input.className = 'order-input';
       input.placeholder = 'Número da encomenda';
+      input.setAttribute('aria-label', 'Número da encomenda');
       input.maxLength = 6;
       input.pattern = "[0-9]*";
       input.oninput = function() { this.value = this.value.replace(/[^0-9]/g, ''); };

--- a/mapa_emel.html
+++ b/mapa_emel.html
@@ -125,7 +125,7 @@
     <h1>Validação Mapa EMEL</h1>
 
     <div class="search-section">
-      <input type="text" id="streetInput" placeholder="Digite o nome da rua ou Código Postal..." onkeyup="filterMap()">
+      <input type="text" id="streetInput" placeholder="Digite o nome da rua ou Código Postal..." aria-label="Procurar rua ou código postal" onkeyup="filterMap()">
       <button class="btn-primary" onclick="validateStreet()">Validar</button>
       <button class="btn-secondary" onclick="window.close()">Fechar</button>
     </div>


### PR DESCRIPTION
### 💡 What
Adicionados atributos `aria-label` em campos de texto (`input`) que utilizavam apenas o atributo `placeholder` para contexto visual. Isso foi feito tanto no campo estático de pesquisa de rua em `mapa_emel.html` quanto nos campos estáticos e dinâmicos de "Número da encomenda" em `comunicacao_bot.html`.

### 🎯 Why
Campos de formulário sem uma tag `<label>` explícita (vinculada via `id`/`for`) nem sempre são anunciados de forma clara por leitores de tela (como o NVDA ou VoiceOver). O uso exclusivo do atributo `placeholder` não é considerado uma prática acessível robusta. A inclusão do `aria-label` resolve este problema silencioso, garantindo que usuários de tecnologias assistivas saibam exatamente o que devem digitar em cada campo.

### 📸 Before/After
*Nenhuma alteração visual. As mudanças operam estritamente na árvore de acessibilidade do DOM.*

### ♿ Accessibility
- O campo `#streetInput` em `mapa_emel.html` agora informa claramente "Procurar rua ou código postal".
- O campo dinâmico de encomenda em `comunicacao_bot.html` (e o criado via Javascript `addOrderField()`) agora expõe "Número da encomenda".

---
*PR created automatically by Jules for task [17882868620287200267](https://jules.google.com/task/17882868620287200267) started by @divilella96*