### PR TITLE
🎨 Palette: Add ARIA labels to search and order inputs for screen readers

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,7 @@
 ## 2024-11-20 - Missing Utility Classes
 **Learning:** Found that accessibility-focused utility classes like `.visually-hidden` were being used in the HTML markup (`mensagem.html`) to hide screen reader text (`#status-announcer`) but were never actually defined in the shared CSS (`style.css`), meaning the text was visibly exposed or broken.
 **Action:** Always verify that utility classes referenced in markup are properly defined in the corresponding stylesheets, particularly those affecting accessibility visibility.
+
+## 2024-06-13 - Missing ARIA Labels on Placeholder-Only Inputs
+**Learning:** Found text inputs (like search inputs and dynamic order fields) relying solely on the `placeholder` attribute for context instead of explicit `<label>` tags. Placeholders frequently disappear upon interaction and are not consistently announced by all screen readers, reducing accessibility for these controls.
+**Action:** Always verify that input fields have either an associated `<label>` or an `aria-label` attribute, specifically when `placeholder` is the only visual cue provided to the user.

--- a/comunicacao_bot.html
+++ b/comunicacao_bot.html
@@ -28,7 +28,7 @@
         <label>Encomendas</label>
         <div id="order-list">
           <div class="order-input-group">
-            <input type="text" class="order-input" placeholder="Número da encomenda" maxlength="6" pattern="[0-9]*" oninput="this.value = this.value.replace(/[^0-9]/g, '');">
+            <input type="text" class="order-input" placeholder="Número da encomenda" aria-label="Número da encomenda" maxlength="6" pattern="[0-9]*" oninput="this.value = this.value.replace(/[^0-9]/g, '');">
             <!-- First one typically doesn't have remove button unless we want to allow 0 orders, but usually at least 1 is needed.
                  Let's add remove button even for the first one for consistency, but maybe handle logic to not remove if it's the only one?
                  Or just let it be empty. -->
@@ -174,6 +174,7 @@
       input.type = 'text';
       input.className = 'order-input';
       input.placeholder = 'Número da encomenda';
+      input.setAttribute('aria-label', 'Número da encomenda');
       input.maxLength = 6;
       input.pattern = "[0-9]*";
       input.oninput = function() { this.value = this.value.replace(/[^0-9]/g, ''); };

--- a/mapa_emel.html
+++ b/mapa_emel.html
@@ -125,7 +125,7 @@
     <h1>Validação Mapa EMEL</h1>
 
     <div class="search-section">
-      <input type="text" id="streetInput" placeholder="Digite o nome da rua ou Código Postal..." onkeyup="filterMap()">
+      <input type="text" id="streetInput" placeholder="Digite o nome da rua ou Código Postal..." aria-label="Nome da rua ou Código Postal" onkeyup="filterMap()">
       <button class="btn-primary" onclick="validateStreet()">Validar</button>
       <button class="btn-secondary" onclick="window.close()">Fechar</button>
     </div>


### PR DESCRIPTION
💡 **What**: Added `aria-label` attributes to text inputs in `mapa_emel.html` (street search) and `comunicacao_bot.html` (order inputs, both static and dynamic).
🎯 **Why**: These input fields were relying exclusively on `placeholder` attributes for context instead of using explicit `<label>` tags. Since placeholders typically disappear when a user starts typing and are not consistently announced by screen readers, these fields were inaccessible to assistive technologies.
📸 **Before/After**: Visually identical, but programmatically accessible to screen readers.
♿ **Accessibility**: Input fields now have clear explicit labels (`aria-label="Nome da rua ou Código Postal"` and `aria-label="Número da encomenda"`) enabling accurate screen reader announcement. Documented this anti-pattern (placeholder-only inputs) in `.Jules/palette.md` to prevent it in the future.

---
*PR created automatically by Jules for task [4835476586396838569](https://jules.google.com/task/4835476586396838569) started by @divilella96*