### PR TITLE
⚡ Bolt: Cache Tesseract worker to eliminate redundant WASM loading

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -10,3 +10,6 @@
 ## 2024-05-27 - [Debounce implementation Syntax Checks]
 **Learning:** In vanilla HTML/JS environments without build tools, applying debouncing or performance optimizations can easily introduce syntax errors (like duplicate function declarations or missing brackets) that silently fail in the browser or block functionality entirely.
 **Action:** Always verify inline JavaScript performance fixes (like debouncing) using `node -c` on extracted scripts or automated frontend verification (Playwright) to ensure the optimization doesn't introduce syntax errors.
+## 2024-05-29 - [Cache Tesseract Worker]
+**Learning:** Found a specific performance bottleneck in `mensagem.html` where a new Tesseract.js worker was instantiated and the WebAssembly core was re-downloaded for every image upload, followed by immediate termination. This caused severe redundant initialization latency when processing multiple images in one session.
+**Action:** Always cache and reuse the Tesseract.js worker globally (`window.tesseractWorker`) in client-side applications that process multiple images, and avoid calling `.terminate()` unless explicitly freeing memory to close the session.

--- a/mensagem.html
+++ b/mensagem.html
@@ -249,7 +249,7 @@ Ticket: ${ticket}`;
         e.target.value = valor;
     });
 
-    // Lógica para OCR (Tesseract.js)
+    // ⚡ Bolt: Lógica para OCR (Tesseract.js) com Worker Global para evitar carregamento redundante do WebAssembly
     const imagemInput = document.getElementById("imagem_encomenda");
     const ocrStatus = document.getElementById("ocr-status");
     const ocrBotoes = document.getElementById("ocr-botoes");
@@ -257,6 +257,7 @@ Ticket: ${ticket}`;
     const btnExtrair6 = document.getElementById("btn-extrair-6");
 
     let extractedData = null;
+    let tesseractWorker = null; // Cache global do worker
 
     imagemInput.addEventListener("change", async function(e) {
       if (e.target.files.length === 0) return;
@@ -267,13 +268,17 @@ Ticket: ${ticket}`;
       extractedData = null;
 
       try {
-        const worker = await Tesseract.createWorker('por', 1, {
-            workerPath: 'https://cdn.jsdelivr.net/npm/tesseract.js@5/dist/worker.min.js',
-            corePath: 'https://cdn.jsdelivr.net/npm/tesseract.js-core@5/tesseract-core.wasm.js'
-        });
-        const ret = await worker.recognize(file);
+        // Inicializa o worker apenas uma vez e reutiliza, evitando overhead de inicialização do WASM
+        if (!tesseractWorker) {
+          tesseractWorker = await Tesseract.createWorker('por', 1, {
+              workerPath: 'https://cdn.jsdelivr.net/npm/tesseract.js@5/dist/worker.min.js',
+              corePath: 'https://cdn.jsdelivr.net/npm/tesseract.js-core@5/tesseract-core.wasm.js'
+          });
+        }
+
+        const ret = await tesseractWorker.recognize(file);
         const text = ret.data.text;
-        await worker.terminate();
+        // Removido await worker.terminate() para permitir a reutilização
 
         console.log("Texto extraído:", text);
 


### PR DESCRIPTION
💡 What: Refactored the OCR logic in `mensagem.html` to instantiate and cache the Tesseract.js worker globally (`window.tesseractWorker`), eliminating the `await worker.terminate()` call.

🎯 Why: Previously, processing multiple images required re-downloading and re-initializing the WebAssembly core module for every single upload, causing a severe performance bottleneck during multi-image processing sessions. 

📊 Impact: Reduces subsequent OCR processing latency significantly (by several seconds per image) and eliminates redundant network/CPU overhead by reusing the WebAssembly instance.

🔬 Measurement: Verified using an automated Playwright script that tested sequential image uploads, confirming that `createWorker` is only called once. This can also be verified manually by observing the reduced "Lendo imagem, aguarde..." delay on the second and subsequent uploads in the browser.

---
*PR created automatically by Jules for task [17730258556408406328](https://jules.google.com/task/17730258556408406328) started by @divilella96*