### PR TITLE
🎨 Palette: [Accessibility] Add ARIA labels to text inputs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,7 @@
 ## 2024-11-20 - Missing Utility Classes
 **Learning:** Found that accessibility-focused utility classes like `.visually-hidden` were being used in the HTML markup (`mensagem.html`) to hide screen reader text (`#status-announcer`) but were never actually defined in the shared CSS (`style.css`), meaning the text was visibly exposed or broken.
 **Action:** Always verify that utility classes referenced in markup are properly defined in the corresponding stylesheets, particularly those affecting accessibility visibility.
+
+## 2024-06-14 - [Accessibility] ARIA Labels on Placeholder Inputs
+**Learning:** Text inputs that rely solely on `placeholder` text for context (lacking a `<label>` element) are completely inaccessible to screen readers, creating a significant UX gap.
+**Action:** Always add descriptive `aria-label` attributes to such inputs (e.g., `<input placeholder="Search..." aria-label="Search items">`), ensuring the label is injected dynamically via JavaScript for newly created elements.

--- a/comunicacao_bot.html
+++ b/comunicacao_bot.html
@@ -28,7 +28,7 @@
         <label>Encomendas</label>
         <div id="order-list">
           <div class="order-input-group">
-            <input type="text" class="order-input" placeholder="Número da encomenda" maxlength="6" pattern="[0-9]*" oninput="this.value = this.value.replace(/[^0-9]/g, '');">
+            <input type="text" class="order-input" aria-label="Número da encomenda" placeholder="Número da encomenda" maxlength="6" pattern="[0-9]*" oninput="this.value = this.value.replace(/[^0-9]/g, '');">
             <!-- First one typically doesn't have remove button unless we want to allow 0 orders, but usually at least 1 is needed.
                  Let's add remove button even for the first one for consistency, but maybe handle logic to not remove if it's the only one?
                  Or just let it be empty. -->
@@ -174,6 +174,7 @@
       input.type = 'text';
       input.className = 'order-input';
       input.placeholder = 'Número da encomenda';
+      input.setAttribute('aria-label', 'Número da encomenda');
       input.maxLength = 6;
       input.pattern = "[0-9]*";
       input.oninput = function() { this.value = this.value.replace(/[^0-9]/g, ''); };

--- a/mapa_emel.html
+++ b/mapa_emel.html
@@ -125,7 +125,7 @@
     <h1>Validação Mapa EMEL</h1>
 
     <div class="search-section">
-      <input type="text" id="streetInput" placeholder="Digite o nome da rua ou Código Postal..." onkeyup="filterMap()">
+      <input type="text" id="streetInput" placeholder="Digite o nome da rua ou Código Postal..." aria-label="Pesquisar rua ou código postal" onkeyup="filterMap()">
       <button class="btn-primary" onclick="validateStreet()">Validar</button>
       <button class="btn-secondary" onclick="window.close()">Fechar</button>
     </div>


### PR DESCRIPTION
**💡 What:** Added explicit `aria-label` attributes to text inputs that rely solely on `placeholder` text for context, both statically in HTML and dynamically in JavaScript.
**🎯 Why:** Text inputs without an associated `<label>` element or `aria-label` are inaccessible to screen readers, causing a significant UX gap for users relying on assistive technology.
**📸 Before/After:** Screen reader users will now hear "Número da encomenda" or "Pesquisar rua ou código postal" instead of just "edit text" or nothing at all.
**♿ Accessibility:** Improves WCAG compliance by ensuring all interactive inputs have an accessible name, benefiting users with visual impairments.

---
*PR created automatically by Jules for task [15557782614191058090](https://jules.google.com/task/15557782614191058090) started by @divilella96*