### PR TITLE
⚡ Bolt: Reuse Tesseract.js worker to eliminate initialization overhead

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -10,3 +10,6 @@
 ## 2024-05-27 - [Debounce implementation Syntax Checks]
 **Learning:** In vanilla HTML/JS environments without build tools, applying debouncing or performance optimizations can easily introduce syntax errors (like duplicate function declarations or missing brackets) that silently fail in the browser or block functionality entirely.
 **Action:** Always verify inline JavaScript performance fixes (like debouncing) using `node -c` on extracted scripts or automated frontend verification (Playwright) to ensure the optimization doesn't introduce syntax errors.
+## 2026-06-15 - [Tesseract.js Worker Reuse]
+**Learning:** In client-side OCR implementations using Tesseract.js, repeatedly calling `Tesseract.createWorker()` and `worker.terminate()` for each image upload introduces severe performance bottlenecks because it forces the browser to re-download, re-parse, and re-initialize the WebAssembly core and language models every time.
+**Action:** When implementing Tesseract.js, always initialize the worker instance once globally and reuse it for subsequent image recognitions, removing `worker.terminate()` unless explicitly necessary for memory management.

--- a/mensagem.html
+++ b/mensagem.html
@@ -258,6 +258,9 @@ Ticket: ${ticket}`;
 
     let extractedData = null;
 
+    // ⚡ Bolt: Global worker instance to prevent redundant WebAssembly initialization overhead on each upload
+    let globalTesseractWorker = null;
+
     imagemInput.addEventListener("change", async function(e) {
       if (e.target.files.length === 0) return;
       const file = e.target.files[0];
@@ -267,13 +270,18 @@ Ticket: ${ticket}`;
       extractedData = null;
 
       try {
-        const worker = await Tesseract.createWorker('por', 1, {
-            workerPath: 'https://cdn.jsdelivr.net/npm/tesseract.js@5/dist/worker.min.js',
-            corePath: 'https://cdn.jsdelivr.net/npm/tesseract.js-core@5/tesseract-core.wasm.js'
-        });
-        const ret = await worker.recognize(file);
+        // ⚡ Bolt: Initialize the worker only once and reuse it
+        if (!globalTesseractWorker) {
+            globalTesseractWorker = await Tesseract.createWorker('por', 1, {
+                workerPath: 'https://cdn.jsdelivr.net/npm/tesseract.js@5/dist/worker.min.js',
+                corePath: 'https://cdn.jsdelivr.net/npm/tesseract.js-core@5/tesseract-core.wasm.js'
+            });
+        }
+
+        const ret = await globalTesseractWorker.recognize(file);
         const text = ret.data.text;
-        await worker.terminate();
+
+        // ⚡ Bolt: Removed worker.terminate() so it can be reused for subsequent file uploads
 
         console.log("Texto extraído:", text);
 


### PR DESCRIPTION
**💡 What:** 
Modified the OCR logic in `mensagem.html` to instantiate the `Tesseract.js` worker once globally (`globalTesseractWorker`) and reuse it for subsequent image uploads, removing the `worker.terminate()` call.

**🎯 Why:** 
Previously, the worker was being created and terminated on every single image upload. This forced the browser to repeatedly download, parse, and initialize the heavy WebAssembly core and language data, causing a massive performance bottleneck and UI delay between selecting an image and seeing the extracted text.

**📊 Impact:** 
Eliminates the multi-second WebAssembly initialization overhead for all subsequent image uploads in a single session. The first upload takes the same time, but all following uploads process almost instantly.

**🔬 Measurement:** 
1. Open `mensagem.html`.
2. Upload an image containing an order number. Wait for the extraction to finish.
3. Upload another image. The extraction will complete significantly faster without the "Lendo imagem, aguarde..." delay caused by worker initialization.

---
*PR created automatically by Jules for task [8943145282305295518](https://jules.google.com/task/8943145282305295518) started by @divilella96*