### PR TITLE
🎨 Palette: Replace blocking alerts with accessible inline validation in aviso_atraso.html

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,7 @@
 ## 2024-11-20 - Missing Utility Classes
 **Learning:** Found that accessibility-focused utility classes like `.visually-hidden` were being used in the HTML markup (`mensagem.html`) to hide screen reader text (`#status-announcer`) but were never actually defined in the shared CSS (`style.css`), meaning the text was visibly exposed or broken.
 **Action:** Always verify that utility classes referenced in markup are properly defined in the corresponding stylesheets, particularly those affecting accessibility visibility.
+
+## 2026-06-15 - Inline Validation with aria-live
+**Learning:** Replacing blocking `alert()` popups with inline `aria-live` regions and `aria-invalid` attributes provides a significantly better user experience and maintains uninterrupted screen reader flow for form validation.
+**Action:** Always prefer accessible inline validation over native browser alerts to provide immediate, contextual feedback.

--- a/aviso_atraso.html
+++ b/aviso_atraso.html
@@ -38,7 +38,8 @@
 
     <form onsubmit="return false;">
       <label for="phones">Números de Telefone</label>
-      <textarea id="phones" placeholder="Insira os números de telefone (separados por vírgula ou nova linha). Ex: 912345678, 961234567"></textarea>
+      <textarea id="phones" placeholder="Insira os números de telefone (separados por vírgula ou nova linha). Ex: 912345678, 961234567" aria-describedby="phones-error"></textarea>
+      <small id="phones-error" style="color:red; display:none; margin-top: 5px;" aria-live="polite"></small>
 
       <label for="time">Hora Prevista de Entrega</label>
       <input type="time" id="time" value="13:30">
@@ -54,16 +55,24 @@
 
   <script>
     function showOptions() {
-      const phonesInput = document.getElementById('phones').value;
+      const phonesElement = document.getElementById('phones');
+      const phonesInput = phonesElement.value;
+      const errorElement = document.getElementById('phones-error');
       const timeInput = document.getElementById('time').value;
       const resultsDiv = document.getElementById('results');
       const linksList = document.getElementById('linksList');
 
-      // Clear previous results
+      // Clear previous results and errors
       linksList.innerHTML = '';
+      errorElement.textContent = '';
+      errorElement.style.display = 'none';
+      phonesElement.removeAttribute('aria-invalid');
 
       if (!phonesInput.trim()) {
-        alert("Por favor, insira pelo menos um número de telefone.");
+        errorElement.textContent = "Por favor, insira pelo menos um número de telefone.";
+        errorElement.style.display = 'block';
+        phonesElement.setAttribute('aria-invalid', 'true');
+        phonesElement.focus();
         return;
       }
 
@@ -72,7 +81,10 @@
       const phones = phonesInput.split(/[\n,;]+/).map(p => p.trim()).filter(p => p !== '');
 
       if (phones.length === 0) {
-        alert("Nenhum número válido encontrado.");
+        errorElement.textContent = "Nenhum número válido encontrado.";
+        errorElement.style.display = 'block';
+        phonesElement.setAttribute('aria-invalid', 'true');
+        phonesElement.focus();
         return;
       }
 


### PR DESCRIPTION
🎨 Palette: Replace blocking alerts with accessible inline validation in aviso_atraso.html

**💡 What:**
Replaced the native, blocking browser `alert()` popups with an accessible inline validation mechanism on the `aviso_atraso.html` page.

**🎯 Why:**
Native alerts halt the user's workflow and provide a poor user experience. Replacing them with an inline error message ensures the user isn't unexpectedly interrupted and gives them immediate, contextual feedback they can see right below the input field while they fix the mistake.

**📸 Before/After:**
- **Before:** When a user tried to submit the form without entering a valid phone number, a browser-level `alert("Por favor, insira pelo menos um número de telefone.")` would pop up, freezing the page.
- **After:** An inline red error message reading "Por favor, insira pelo menos um número de telefone." appears beneath the textarea, and the field is highlighted and focused automatically.

**♿ Accessibility:**
- Added `<small id="phones-error" aria-live="polite">` so screen readers automatically announce the error message when it appears.
- Added `aria-describedby="phones-error"` to the textarea to programmatically connect the error to the input.
- Added `aria-invalid="true"` dynamically to the textarea when the validation fails.
- Set `.focus()` on the textarea when an error occurs so keyboard and screen reader users are immediately placed where they need to make the correction.

---
*PR created automatically by Jules for task [760211921340702091](https://jules.google.com/task/760211921340702091) started by @divilella96*