### PR TITLE
⚡ Bolt: Cache Tesseract WebWorker in `mensagem.html`

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -10,3 +10,6 @@
 ## 2024-05-27 - [Debounce implementation Syntax Checks]
 **Learning:** In vanilla HTML/JS environments without build tools, applying debouncing or performance optimizations can easily introduce syntax errors (like duplicate function declarations or missing brackets) that silently fail in the browser or block functionality entirely.
 **Action:** Always verify inline JavaScript performance fixes (like debouncing) using `node -c` on extracted scripts or automated frontend verification (Playwright) to ensure the optimization doesn't introduce syntax errors.
+## 2024-05-28 - [Tesseract WebWorker Overhead]
+**Learning:** In a vanilla HTML environment using Tesseract.js for client-side OCR, initializing and terminating the `TesseractWorker` on every image upload (e.g., `worker.terminate()`) introduces a massive, unnecessary performance bottleneck due to redundant WebAssembly file loading and initialization overhead.
+**Action:** Always initialize client-side WebAssembly workers (like Tesseract.js) globally and reuse the same instance for subsequent processing tasks instead of re-instantiating them for each event.

--- a/mensagem.html
+++ b/mensagem.html
@@ -257,6 +257,7 @@ Ticket: ${ticket}`;
     const btnExtrair6 = document.getElementById("btn-extrair-6");
 
     let extractedData = null;
+    let tesseractWorker = null; // ⚡ Bolt: Global worker to avoid redundant WebAssembly loading
 
     imagemInput.addEventListener("change", async function(e) {
       if (e.target.files.length === 0) return;
@@ -267,13 +268,14 @@ Ticket: ${ticket}`;
       extractedData = null;
 
       try {
-        const worker = await Tesseract.createWorker('por', 1, {
-            workerPath: 'https://cdn.jsdelivr.net/npm/tesseract.js@5/dist/worker.min.js',
-            corePath: 'https://cdn.jsdelivr.net/npm/tesseract.js-core@5/tesseract-core.wasm.js'
-        });
-        const ret = await worker.recognize(file);
+        if (!tesseractWorker) {
+          tesseractWorker = await Tesseract.createWorker('por', 1, {
+              workerPath: 'https://cdn.jsdelivr.net/npm/tesseract.js@5/dist/worker.min.js',
+              corePath: 'https://cdn.jsdelivr.net/npm/tesseract.js-core@5/tesseract-core.wasm.js'
+          });
+        }
+        const ret = await tesseractWorker.recognize(file);
         const text = ret.data.text;
-        await worker.terminate();
 
         console.log("Texto extraído:", text);
 


### PR DESCRIPTION
💡 What: Extracts Tesseract.js worker initialization into a global variable (`tesseractWorker`) in `mensagem.html` and removes the `.terminate()` call after each OCR read.
🎯 Why: Previously, the app loaded the large WebAssembly core and initialized a new WebWorker on every single image upload, causing massive CPU/Network overhead and severe performance bottlenecks.
📊 Impact: Expected to reduce subsequent image OCR processing time by ~80% since the heavy lifting (downloading and initializing wasm) is done only once per session.
🔬 Measurement: Upload two images consecutively. The first will take standard time; the second should process almost instantly compared to before. This was verified using a temporary Playwright script checking log timing.

---
*PR created automatically by Jules for task [6537264007576667170](https://jules.google.com/task/6537264007576667170) started by @divilella96*