### PR TITLE
🎨 Palette: Improve form validation with inline feedback

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,7 @@
 ## 2024-11-20 - Missing Utility Classes
 **Learning:** Found that accessibility-focused utility classes like `.visually-hidden` were being used in the HTML markup (`mensagem.html`) to hide screen reader text (`#status-announcer`) but were never actually defined in the shared CSS (`style.css`), meaning the text was visibly exposed or broken.
 **Action:** Always verify that utility classes referenced in markup are properly defined in the corresponding stylesheets, particularly those affecting accessibility visibility.
+
+## 2024-11-20 - Inline Validation Accessibility
+**Learning:** For screen readers to properly announce inline form validation errors in vanilla JS, you must explicitly connect the input to the error message (`aria-describedby`), make the error container live (`aria-live="polite"`), and dynamically toggle the invalid state on the input itself (`aria-invalid="true"/"false"`).
+**Action:** When implementing custom regex validation or input masking in vanilla JS forms, always include these three ARIA attributes to ensure the error state is communicable to assistive technologies.

--- a/contact.html
+++ b/contact.html
@@ -13,8 +13,8 @@
 
     <form id="contactForm">
       <label for="encomenda">Número da Encomenda</label>
-      <input type="tel" id="encomenda" name="encomenda" placeholder="Ex: 00035625 / 530729" required inputmode="numeric">
-      <small id="erro-encomenda" style="color:red; display:none;">
+      <input type="tel" id="encomenda" name="encomenda" placeholder="Ex: 00035625 / 530729" required inputmode="numeric" aria-describedby="erro-encomenda">
+      <small id="erro-encomenda" style="color:red; display:none;" aria-live="polite">
       ⚠️ O número após a barra deve ter exatamente 6 dígitos.
       </small>
 
@@ -126,7 +126,10 @@
     });
 
     // Máscara para o campo "Encomenda"
-    document.getElementById("encomenda").addEventListener("input", function(e) {
+    const campoEncomenda = document.getElementById("encomenda");
+    const erro = document.getElementById("erro-encomenda");
+
+    campoEncomenda.addEventListener("input", function(e) {
       let valor = e.target.value.replace(/[^0-9/]/g, "");
       if (valor.includes("/")) {
         let [antes, depois] = valor.split("/");
@@ -137,10 +140,16 @@
         if (depois.length === 6) {
           erro.style.display = "none";
           e.target.setCustomValidity("");
+          e.target.removeAttribute("aria-invalid");
         } else {
           erro.style.display = "block";
           e.target.setCustomValidity("O número após a barra deve ter exatamente 6 dígitos.");
+          e.target.setAttribute("aria-invalid", "true");
         }
+      } else {
+        erro.style.display = "none";
+        e.target.setCustomValidity("");
+        e.target.removeAttribute("aria-invalid");
       }
       e.target.value = valor;
     });

--- a/mensagem.html
+++ b/mensagem.html
@@ -39,8 +39,9 @@
         placeholder="Ex: 00035625 / 530729"
         required
         inputmode="numeric"
+        aria-describedby="erro-encomenda"
       />
-      <small id="erro-encomenda" style="color:red; display:none;">
+      <small id="erro-encomenda" style="color:red; display:none;" aria-live="polite">
       ⚠️ O número após a barra deve ter exatamente 6 dígitos.
       </small>
 
@@ -241,10 +242,16 @@ Ticket: ${ticket}`;
         if (depois.length === 6) {
             erro.style.display = "none";
             campoEncomenda.setCustomValidity("");
+            campoEncomenda.removeAttribute("aria-invalid");
         } else {
             erro.style.display = "block";
             campoEncomenda.setCustomValidity("O número após a barra deve ter exatamente 6 dígitos.");
+            campoEncomenda.setAttribute("aria-invalid", "true");
         }
+        } else {
+            erro.style.display = "none";
+            campoEncomenda.setCustomValidity("");
+            campoEncomenda.removeAttribute("aria-invalid");
         }
         e.target.value = valor;
     });


### PR DESCRIPTION
### 💡 What:
Added ARIA attributes to the inline validation for the "Número da Encomenda" fields in `contact.html` and `mensagem.html`.

### 🎯 Why:
To ensure that screen reader users are immediately and clearly notified when they enter an invalid order number format, providing them with the necessary context to correct the input.

### 📸 Before/After:
*   **Before:** Visual-only error text (`<small>`) displayed when validation failed. Screen readers would not announce the error, nor would they know the input was in an invalid state.
*   **After:** The input is linked to the error message via `aria-describedby`. The error message container has `aria-live="polite"` so it is announced when it appears. The input itself dynamically toggles `aria-invalid="true"` when the validation fails.

### ♿ Accessibility:
*   Added `aria-describedby` to link the input to its specific error message.
*   Added `aria-live="polite"` to the error message container.
*   Dynamically toggle `aria-invalid` attribute via JavaScript based on the validation state.

---
*PR created automatically by Jules for task [15929560194279325879](https://jules.google.com/task/15929560194279325879) started by @divilella96*