### PR TITLE
🎨 Palette: Add ARIA labels to text inputs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,7 @@
 ## 2024-11-20 - Missing Utility Classes
 **Learning:** Found that accessibility-focused utility classes like `.visually-hidden` were being used in the HTML markup (`mensagem.html`) to hide screen reader text (`#status-announcer`) but were never actually defined in the shared CSS (`style.css`), meaning the text was visibly exposed or broken.
 **Action:** Always verify that utility classes referenced in markup are properly defined in the corresponding stylesheets, particularly those affecting accessibility visibility.
+
+## 2026-06-17 - Missing ARIA Labels on Placeholder-Only Inputs
+**Learning:** Found multiple inputs in the application (`mapa_emel.html` and `comunicacao_bot.html`) that rely entirely on the `placeholder` attribute for context, lacking visible `<label>` wrappers. This severely degrades accessibility for screen reader users as structural semantics are missing.
+**Action:** Always add an explicit `aria-label` attribute to any input that depends solely on a placeholder text, including dynamically generated DOM elements.

--- a/comunicacao_bot.html
+++ b/comunicacao_bot.html
@@ -28,7 +28,7 @@
         <label>Encomendas</label>
         <div id="order-list">
           <div class="order-input-group">
-            <input type="text" class="order-input" placeholder="Número da encomenda" maxlength="6" pattern="[0-9]*" oninput="this.value = this.value.replace(/[^0-9]/g, '');">
+            <input type="text" class="order-input" aria-label="Número da encomenda" placeholder="Número da encomenda" maxlength="6" pattern="[0-9]*" oninput="this.value = this.value.replace(/[^0-9]/g, '');">
             <!-- First one typically doesn't have remove button unless we want to allow 0 orders, but usually at least 1 is needed.
                  Let's add remove button even for the first one for consistency, but maybe handle logic to not remove if it's the only one?
                  Or just let it be empty. -->
@@ -173,6 +173,7 @@
       const input = document.createElement('input');
       input.type = 'text';
       input.className = 'order-input';
+      input.setAttribute('aria-label', 'Número da encomenda');
       input.placeholder = 'Número da encomenda';
       input.maxLength = 6;
       input.pattern = "[0-9]*";

--- a/mapa_emel.html
+++ b/mapa_emel.html
@@ -125,7 +125,7 @@
     <h1>Validação Mapa EMEL</h1>
 
     <div class="search-section">
-      <input type="text" id="streetInput" placeholder="Digite o nome da rua ou Código Postal..." onkeyup="filterMap()">
+      <input type="text" id="streetInput" aria-label="Digite o nome da rua ou Código Postal" placeholder="Digite o nome da rua ou Código Postal..." onkeyup="filterMap()">
       <button class="btn-primary" onclick="validateStreet()">Validar</button>
       <button class="btn-secondary" onclick="window.close()">Fechar</button>
     </div>


### PR DESCRIPTION
**💡 What:** Added `aria-label` attributes to text inputs that rely exclusively on the `placeholder` attribute for context. This includes the static input in `mapa_emel.html` and both static and dynamically generated inputs in `comunicacao_bot.html`.

**🎯 Why:** Screen readers do not reliably announce `placeholder` text as the primary label for an input field. By relying only on placeholders without a visible `<label>`, visually impaired users lose critical context about what the field is for.

**📸 Before/After:** (No visual changes, purely structural/semantic)

**♿ Accessibility:** Improved structural accessibility for screen reader users by providing an explicit `aria-label` to these input fields, ensuring they are properly announced during keyboard navigation or exploration.

---
*PR created automatically by Jules for task [4099980166390442402](https://jules.google.com/task/4099980166390442402) started by @divilella96*