### PR TITLE
Hide Rato store operations section

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,9 +23,11 @@
       <button class="btn-primary" onclick="abrirMensagemWhatsApp()">Report Bloqueio POS</button>
       <button class="btn-primary" onclick="abrirPaginaContato()">E-mail Artigo Esquecido</button>
 
-      <h2>Rato</h2>
-      <button class="btn-primary" onclick="abrirLiveOperationsRato()">Rato - Em Direto</button>
-      <button class="btn-primary" onclick="abrirRotaRato()">ROTA Rato</button>
+      <div style="display: none;">
+        <h2>Rato</h2>
+        <button class="btn-primary" onclick="abrirLiveOperationsRato()">Rato - Em Direto</button>
+        <button class="btn-primary" onclick="abrirRotaRato()">ROTA Rato</button>
+      </div>
       <h2>São Bento</h2>
       <button class="btn-primary" onclick="abrirLiveOperationsSaoBento()">São Bento - Em Direto</button>
       <button class="btn-primary" onclick="abrirRotaSaoBento()">ROTA São Bento</button>


### PR DESCRIPTION
Wrapped the "Rato" section (heading and two action buttons) in `index.html` within a `<div style="display: none;">`. This correctly hides the inactive options from the frontend UI as the Rato store is currently not operating, while retaining the code for potential future use. Verified using Playwright.

---
*PR created automatically by Jules for task [13347780200878506466](https://jules.google.com/task/13347780200878506466) started by @divilella96*