### PR TITLE
Fix JSON dataset string cleanup and link deduplication

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,7 @@
         <div style="display: flex; gap: 10px;">
           <button class="btn-primary btn-add" id="btnCrawler" onclick="rodarCrawler()" style="flex: 1;">Extrair Dados</button>
           <button class="btn-secondary" id="btnTop20" onclick="verTop20()" style="flex: 1;">Ver Top 20 Produtos</button>
+          <button class="btn-secondary" id="btnCorrigirJson" onclick="corrigirJson()" style="flex: 1;" title="Limpar quantidades e remover duplicados">Corrigir JSON</button>
         </div>
       </div>
       <div id="statusCrawler" aria-live="polite" style="font-size: 0.9rem; margin-bottom: 10px; min-height: 20px;"></div>
@@ -227,6 +228,37 @@
         statusEl.style.color = '#dc3545';
       } finally {
         btnCrawler.disabled = false;
+      }
+    }
+
+    async function corrigirJson() {
+      const statusEl = document.getElementById('statusCrawler');
+      const resultadoEl = document.getElementById('resultadoCrawler');
+      const btnCorrigirJson = document.getElementById('btnCorrigirJson');
+
+      statusEl.textContent = 'A corrigir JSON...';
+      statusEl.style.color = '#007bff';
+      resultadoEl.style.display = 'none';
+      btnCorrigirJson.disabled = true;
+
+      try {
+        const response = await fetch('http://localhost:3000/api/corrigir-json', {
+          method: 'POST'
+        });
+        const data = await response.json();
+
+        if (response.ok) {
+          statusEl.textContent = data.message || 'JSON corrigido com sucesso!';
+          statusEl.style.color = '#28a745';
+        } else {
+          statusEl.textContent = 'Erro: ' + (data.error || 'Falha ao corrigir JSON');
+          statusEl.style.color = '#dc3545';
+        }
+      } catch (error) {
+        statusEl.textContent = 'Erro de conexão com o servidor local. O server.js está rodando?';
+        statusEl.style.color = '#dc3545';
+      } finally {
+        btnCorrigirJson.disabled = false;
       }
     }
 

--- a/scripts/crawler_lyzer.js
+++ b/scripts/crawler_lyzer.js
@@ -89,9 +89,15 @@ const DATA_FIM = '';    // ex: '2026-07-22'
                     const qtyDiv = nameDiv ? nameDiv.nextElementSibling : null;
 
                     if (nameDiv && qtyDiv) {
+                        let qtyText = qtyDiv.innerText.trim() || '0';
+                        if (qtyText.includes('/')) {
+                            const parts = qtyText.split('/');
+                            qtyText = parts[parts.length - 1].trim();
+                        }
+
                         resultados.push({
                             nome: nameDiv.innerText.trim(),
-                            quantidadeTexto: qtyDiv.innerText.trim() || '0'
+                            quantidadeTexto: qtyText
                         });
                     }
                 });
@@ -129,7 +135,7 @@ const DATA_FIM = '';    // ex: '2026-07-22'
         }
 
         dadosRelatorio.forEach(novaEncomenda => {
-            const index = historico.findIndex(enc => enc.encomenda === novaEncomenda.encomenda);
+            const index = historico.findIndex(enc => enc.link === novaEncomenda.link);
             if (index !== -1) {
                 historico[index] = novaEncomenda;
             } else {

--- a/server.js
+++ b/server.js
@@ -107,9 +107,15 @@ app.post('/api/crawler', async (req, res) => {
                     const qtyDiv = nameDiv ? nameDiv.nextElementSibling : null;
 
                     if (nameDiv && qtyDiv) {
+                        let qtyText = qtyDiv.innerText.trim() || '0';
+                        if (qtyText.includes('/')) {
+                            const parts = qtyText.split('/');
+                            qtyText = parts[parts.length - 1].trim();
+                        }
+
                         resultados.push({
                             nome: nameDiv.innerText.trim(),
-                            quantidadeTexto: qtyDiv.innerText.trim() || '0'
+                            quantidadeTexto: qtyText
                         });
                     }
                 });
@@ -149,7 +155,7 @@ app.post('/api/crawler', async (req, res) => {
 
         // Adiciona novos itens, atualizando encomendas existentes se necessário
         dadosRelatorio.forEach(novaEncomenda => {
-            const index = historico.findIndex(enc => enc.encomenda === novaEncomenda.encomenda);
+            const index = historico.findIndex(enc => enc.link === novaEncomenda.link);
             if (index !== -1) {
                 historico[index] = novaEncomenda;
             } else {
@@ -170,6 +176,65 @@ app.post('/api/crawler', async (req, res) => {
         if (browser) {
             await browser.close();
         }
+    }
+});
+
+app.post('/api/corrigir-json', (req, res) => {
+    const jsonPath = path.join(__dirname, 'dados_encomendas.json');
+    if (!fs.existsSync(jsonPath)) {
+        return res.json({ success: true, message: 'Nenhum histórico encontrado para corrigir.' });
+    }
+
+    try {
+        const fileData = fs.readFileSync(jsonPath, 'utf-8');
+        let historico = JSON.parse(fileData);
+        let correctedCount = 0;
+
+        // Deduplicate using link as primary key
+        const deduplicatedHistorico = [];
+        const seenLinks = new Set();
+
+        // Reverse iterate to keep the latest added/updated order in case of duplicates
+        for (let i = historico.length - 1; i >= 0; i--) {
+            const enc = historico[i];
+            if (!seenLinks.has(enc.link)) {
+                seenLinks.add(enc.link);
+                deduplicatedHistorico.unshift(enc); // Add to beginning to maintain original chronological order
+            }
+        }
+
+        historico = deduplicatedHistorico;
+
+        historico.forEach(encomenda => {
+            let totalItens = 0;
+            const listaNomes = [];
+
+            if (encomenda.produtosDetalhes) {
+                encomenda.produtosDetalhes.forEach(prod => {
+                    let qtyText = prod.quantidadeTexto || '0';
+                    if (qtyText.includes('/')) {
+                        const parts = qtyText.split('/');
+                        qtyText = parts[parts.length - 1].trim();
+                        prod.quantidadeTexto = qtyText;
+                        correctedCount++;
+                    }
+
+                    const qtdNumero = parseInt(prod.quantidadeTexto, 10) || 0;
+                    totalItens += qtdNumero;
+                    listaNomes.push(`${prod.nome} (${prod.quantidadeTexto})`);
+                });
+
+                encomenda.quantidadeTotal = totalItens;
+                encomenda.listaCompleta = listaNomes.join(' | ');
+            }
+        });
+
+        fs.writeFileSync(jsonPath, JSON.stringify(historico, null, 2), 'utf-8');
+        res.json({ success: true, message: `JSON corrigido com sucesso! ${historico.length} encomendas mantidas após deduplicação, ${correctedCount} quantidades atualizadas.` });
+
+    } catch (error) {
+        console.error('Erro ao corrigir o JSON:', error);
+        res.status(500).json({ success: false, error: 'Erro ao corrigir o JSON.' });
     }
 });
 


### PR DESCRIPTION
Implements string sanitization for order item quantities by isolating right-side values in composite strings like `5/7` or `0.8/1 Kg` to produce clean numeric or metric readouts. Adds the `/api/corrigir-json` route and respective UI button to clean up and retroactively sanitize previously downloaded items in `dados_encomendas.json`. Additionally, shifts primary deduplication key from ambiguous order IDs to exact order URLs (`link`).

---
*PR created automatically by Jules for task [18082765882443911823](https://jules.google.com/task/18082765882443911823) started by @divilella96*