### PR TITLE
feat(dashboard): add PDF export functionality via native print

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,10 @@
     <div class="modal-content">
       <div class="modal-header">
         <h2 id="tituloModalTop20" style="margin: 0; color: var(--primary-color);">Top 20 Produtos</h2>
-        <button class="btn-close" onclick="fecharModal()">&times;</button>
+        <div style="display: flex; gap: 10px;">
+          <button class="btn-primary" id="btnExportarPdf" onclick="imprimirModal()" style="padding: 6px 12px; font-size: 0.9rem; width: auto;" title="Exportar lista para PDF via janela de impressão">PDF</button>
+          <button class="btn-close" onclick="fecharModal()">&times;</button>
+        </div>
       </div>
       <div class="modal-body">
         <ul id="listaTopProdutos" class="ranking-list"></ul>
@@ -78,6 +81,12 @@
   <script>
     function fecharModal() {
       document.getElementById('top20Modal').classList.remove('active');
+    }
+
+    function imprimirModal() {
+      // Dispara a janela de impressão nativa do navegador
+      // O CSS `@media print` será responsável por ocultar o resto da página
+      window.print();
     }
 
     function pesquisarEncomenda() {

--- a/style.css
+++ b/style.css
@@ -410,3 +410,51 @@ form button {
   clip: rect(0, 0, 0, 0);
   border: 0;
 }
+
+/* Print Styles for PDF Export */
+@media print {
+  body * {
+    visibility: hidden;
+  }
+
+  /* Show only the modal */
+  #top20Modal, #top20Modal * {
+    visibility: visible;
+  }
+
+  /* Position the modal exactly at the top of the printed page */
+  #top20Modal {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    background: none;
+    display: block; /* ensure it displays when active */
+  }
+
+  .modal-content {
+    width: 100%;
+    max-width: 100%;
+    box-shadow: none;
+    border-radius: 0;
+    border: none;
+  }
+
+  /* Hide the close and export buttons in the print */
+  #btnExportarPdf,
+  .btn-close {
+    display: none !important;
+  }
+
+  .modal-body {
+    overflow: visible; /* Prevent scrollbars in print */
+    padding: 0;
+  }
+
+  .ranking-list li {
+    border: 1px solid #ccc;
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+}


### PR DESCRIPTION
- Added a "PDF" export button to the Top 20 modal in `index.html`.
- Implemented `imprimirModal()` to leverage native `window.print()` without needing external dependencies.
- Added `@media print` rules to `style.css` to hide the entire UI except the modal, and to suppress the close and PDF buttons from appearing in the exported document.